### PR TITLE
Add DateTimeNormalizer in the default Serializer

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace JoliCode\Elastically;
 use Elastica\Client as ElasticaClient;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -49,6 +50,7 @@ class Client extends ElasticaClient
         // Use a minimal default serializer
         return new Serializer([
             new ArrayDenormalizer(),
+            new DateTimeNormalizer(),
             new ObjectNormalizer(),
         ], [
             new JsonEncoder(),


### PR DESCRIPTION
When not present, \DateTime object are normalized by ObjectNormalizer and that does not look good ^^