### PR TITLE
Add HttpClientTransport for Symfony HttpClient on Elastica

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ JoliCode\Elastically\Client:
             elastically_bulk_size: 100
 ```
 
+### Using HttpClient as Transport
+
 You can also use the Symfony HttpClient for all Elastica communications:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Opinionated [Elastica](https://github.com/ruflin/Elastica) based framework to bo
 - Analysis is separated from mappings;
 - 100% compatibility with [ruflin/elastica](https://github.com/ruflin/Elastica);
 - Designed for Elasticsearch 7+ (no types), compatible with both ES 6 and ES 7;
+- Symfony HttpClient compatible transport;
 - Extra commands to monitor, update mapping, reindex... Commonly implemented tasks.
 
 ## Demo
@@ -206,6 +207,19 @@ JoliCode\Elastically\Client:
             elastically_index_class_mapping:
                 my_index_name: \App\Model\MyModel
             elastically_bulk_size: 100
+```
+
+You can also use the Symfony HttpClient for all Elastica communications:
+
+```yaml
+JoliCode\Elastically\Transport\HttpClientTransport: ~
+
+JoliCode\Elastically\Client:
+    arguments:
+        $config:
+            host: '%env(ELASTICSEARCH_HOST)%'
+            transport: '@JoliCode\Elastically\Transport\HttpClientTransport'
+            ...
 ```
 
 ## To be done

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^8",
+        "symfony/http-client": "^4.3|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Transport/HttpClientTransport.php
+++ b/src/Transport/HttpClientTransport.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace JoliCode\Elastically\Transport;
+
+use Elastica\Connection;
+use Elastica\Exception\Connection\HttpException;
+use Elastica\Exception\PartialShardFailureException;
+use Elastica\Exception\ResponseException;
+use Elastica\Request;
+use Elastica\Response;
+use Elastica\Transport\AbstractTransport;
+use Elastica\Util;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\ServerException;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Implement Symfony HttpClient as an Elastica Transport
+ */
+class HttpClientTransport extends AbstractTransport
+{
+    private $client;
+
+    /**
+     * Elastica Connection does not have this option
+     */
+    private $scheme;
+
+    public function __construct(HttpClientInterface $client, string $scheme = 'http', ?Connection $connection = null)
+    {
+        parent::__construct($connection);
+
+        $this->client = $client;
+        $this->scheme = $scheme;
+    }
+
+    public function exec(Request $request, array $params): Response
+    {
+        $connection = $this->getConnection();
+
+        $headers = $connection->hasConfig('headers') && \is_array($connection->getConfig('headers'))
+            ? $connection->getConfig('headers')
+            : [];
+        $headers['Content-Type'] = $request->getContentType();
+
+        $options = [
+            'headers' => $headers,
+            'json' => $request->getData(),
+        ];
+
+
+        if ($connection->getTimeout()) {
+            $options['timeout'] = $connection->getTimeout();
+        }
+
+        $proxy = $connection->getProxy();
+        if (!\is_null($proxy)) {
+            $options['proxy'] = $proxy;
+        }
+
+        try {
+            $response = $this->client->request($request->getMethod(), $this->_getUri($request, $connection), $options);
+            $elasticaResponse = new Response($response->getContent(), $response->getStatusCode());
+        } catch (ClientException $e) {
+            $elasticaResponse = new Response($response->getContent(false), $response->getStatusCode());
+            throw new ResponseException($request, $elasticaResponse);
+        } catch (ServerException $e) {
+            $elasticaResponse = new Response($response->getContent(false), $response->getStatusCode());
+            throw new ResponseException($request, $elasticaResponse);
+        } catch (HttpExceptionInterface $e) {
+            throw new HttpException($e->getCode(), $request);
+        }
+
+        if ($connection->hasConfig('bigintConversion')) {
+            $elasticaResponse->setJsonBigintConversion($connection->getConfig('bigintConversion'));
+        }
+
+        $elasticaResponse->setTransferInfo($response->getInfo());
+
+        if ($elasticaResponse->hasError()) {
+            throw new ResponseException($request, $elasticaResponse);
+        }
+
+        if ($elasticaResponse->hasFailedShards()) {
+            throw new PartialShardFailureException($request, $elasticaResponse);
+        }
+
+        return $elasticaResponse;
+    }
+
+    protected function _getUri(Request $request, Connection $connection): string
+    {
+        $url = $connection->hasConfig('url') ? $connection->getConfig('url') : '';
+
+        if (!empty($url)) {
+            $baseUri = $url;
+        } else {
+            $baseUri = $this->scheme.'://'.$connection->getHost().':'.$connection->getPort().'/'.$connection->getPath();
+        }
+
+        $requestPath = $request->getPath();
+        if (!Util::isDateMathEscaped($requestPath)) {
+            $requestPath = Util::escapeDateMath($requestPath);
+        }
+
+        $baseUri .= $requestPath;
+
+        $query = $request->getQuery();
+
+        if (!empty($query)) {
+            $baseUri .= '?'.\http_build_query($this->sanityzeQueryStringBool($query));
+        }
+
+        return $baseUri;
+    }
+}

--- a/tests/Transport/HttpClientTransportTest.php
+++ b/tests/Transport/HttpClientTransportTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Transport;
+
+use Elastica\Exception\ExceptionInterface;
+use JoliCode\Elastically\Client;
+use JoliCode\Elastically\ResultSet;
+use JoliCode\Elastically\Tests\BaseTestCase;
+use JoliCode\Elastically\Transport\HttpClientTransport;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class HttpClientTransportTest extends BaseTestCase
+{
+    public function testHttpClientIsCalledOnSearch()
+    {
+        $responses = [
+            new MockResponse(<<<JSON
+{
+  "took" : 1,
+  "timed_out" : false,
+  "hits" : {
+    "total" : {
+      "value" : 0,
+      "relation" : "eq"
+    },
+    "max_score" : null,
+    "hits" : [ ]
+  }
+}
+JSON
+),
+        ];
+
+        $client = new Client([
+            'log' => false,
+            'transport' => new HttpClientTransport(new MockHttpClient($responses)),
+        ]);
+
+        $results = $client->getIndex(__FUNCTION__)->search();
+
+        $this->assertInstanceOf(ResultSet::class, $results);
+        $this->assertEquals(0, $results->getTotalHits());
+    }
+
+    public function testHttpClientHandleErrorIdentically()
+    {
+        $clientHttpClient = new Client([
+            'log' => false,
+            'transport' => new HttpClientTransport(HttpClient::create()),
+        ]);
+
+        $clientNativeTransport = new Client([
+            'log' => false,
+        ]);
+
+        $this->runOnBothAndCompare($clientHttpClient, $clientNativeTransport);
+
+        $clientHttpClient = new Client([
+            'log' => false,
+            'host' => 'MALFORMED:828282',
+            'transport' => new HttpClientTransport(HttpClient::create()),
+        ]);
+
+        $clientNativeTransport = new Client([
+            'host' => 'MALFORMED:828282',
+            'log' => false,
+        ]);
+
+        $this->runOnBothAndCompare($clientHttpClient, $clientNativeTransport);
+
+        $clientHttpClient = new Client([
+            'log' => false,
+            'proxy' => '127.0.0.1:9292',
+            'transport' => new HttpClientTransport(HttpClient::create()),
+        ]);
+
+        $clientNativeTransport = new Client([
+            'proxy' => '127.0.0.1:9292',
+            'log' => false,
+        ]);
+
+        $this->runOnBothAndCompare($clientHttpClient, $clientNativeTransport);
+    }
+
+    protected function runOnBothAndCompare(Client $clientHttpClient, Client $clientNative)
+    {
+        try {
+            $clientHttpClient->getIndex(__FUNCTION__)->search();
+            $this->assertFalse(true, 'No exception thrown by HttpClient!');
+
+            return;
+        } catch (\PHPUnit\Exception $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            $httpClientException = $e;
+        }
+
+        try {
+            $clientNative->getIndex(__FUNCTION__)->search();
+
+            $this->assertFalse(true, 'No exception thrown by Native Client!');
+
+            return;
+        } catch (\PHPUnit\Exception $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            $nativeException = $e;
+        }
+
+        $this->assertInstanceOf(ExceptionInterface::class, $nativeException);
+        $this->assertInstanceOf(ExceptionInterface::class, $httpClientException);
+        $this->assertSame(get_class($httpClientException), get_class($nativeException));
+    }
+}


### PR DESCRIPTION
This PR add a new Transport for Elastica, allowing to route all HTTP requests to Symfony HttpClient.

This is nice because it's 100% compatible and you get all the nice things in the HttpClient, for example, debug screen:

![image](https://user-images.githubusercontent.com/225704/72008255-b2b37080-3253-11ea-85c8-9c0b59e3c2ff.png)

# todo 

- [x] Add tests :grimacing: 