### PR TITLE
Add experimental support for Symfony Messenger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## Run test suite
-	./vendor/bin/phpunit --bootstrap vendor/autoload.php --testdox --colors=always tests
+	./vendor/bin/simple-phpunit
 
 start: ## Start testing tools (Elasticsearch)
 	docker run --rm -d --name "elastically_es" -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.4.0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test: ## Run test suite
 	./vendor/bin/phpunit --bootstrap vendor/autoload.php --testdox --colors=always tests
 
 start: ## Start testing tools (Elasticsearch)
-	docker run -d --name "elastically_es" -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.4.0
+	docker run --rm -d --name "elastically_es" -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.4.0
 
 stop: ## Stop testing tools (Elasticsearch)
 	docker stop "elastically_es"

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ $ php bin/console messenger:consume async
 
 ### Grouping IndexationRequest in a spool
 
-Sending multiple `IndexationRequest` during the same Symfony Request is not always appropriate, it will trigger multiple Bulk operations. Elastically provide a Kernel terminate listener to group all the `IndexationRequest` in a single `MultipleIndexationRequest` message.
+Sending multiple `IndexationRequest` during the same Symfony Request is not always appropriate, it will trigger multiple Bulk operations. Elastically provides a Kernel terminate listener to group all the `IndexationRequest` in a single `MultipleIndexationRequest` message.
 
 To use this mechanism, we send the simple `IndexationRequest` in a memory transport to be consumed and grouped in a really async transport:
 

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ $ php bin/console messenger:consume async
 
 ### Grouping IndexationRequest in a spool
 
-Sending multiple `IndexationRequest` during the same Symfony Request is not always appropriate, it will trigger multiple Bulk operations. Elastically provides a Kernel terminate listener to group all the `IndexationRequest` in a single `MultipleIndexationRequest` message.
+Sending multiple `IndexationRequest` during the same Symfony Request is not always appropriate, it will trigger multiple Bulk operations. Elastically provides a Kernel listener to group all the `IndexationRequest` in a single `MultipleIndexationRequest` message.
 
-To use this mechanism, we send the simple `IndexationRequest` in a memory transport to be consumed and grouped in a really async transport:
+To use this mechanism, we send the `IndexationRequest` in a memory transport to be consumed and grouped in a really async transport:
 
 ```yaml
 messenger:
@@ -264,7 +264,7 @@ messenger:
         'JoliCode\Elastically\Messenger\IndexationRequest': queuing
 ```
 
-You also need to register the event:
+You also need to register the subscriber:
 
 ```yaml
 services:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Opinionated [Elastica](https://github.com/ruflin/Elastica) based framework to bo
 - Analysis is separated from mappings;
 - 100% compatibility with [ruflin/elastica](https://github.com/ruflin/Elastica);
 - Designed for Elasticsearch 7+ (no types), compatible with both ES 6 and ES 7;
-- Symfony Messenger Handler support;
+- Symfony Messenger Handler support (with or without spool);
 - Extra commands to monitor, update mapping, reindex... Commonly implemented tasks.
 
 ## Demo
@@ -173,7 +173,96 @@ Add a prefix to all indexes and aliases created via Elastically.
 
 _Default to `null`._
 
+## Usage in Symfony
+
+### Client as a service
+
+Just declare the proper service in `services.yaml`:
+
+```yaml
+JoliCode\Elastically\Client:
+    arguments:
+        $config:
+            log: '%kernel.debug%'
+            host: '%env(ELASTICSEARCH_HOST)%'
+            elastically_mappings_directory: '%kernel.root_dir%/Elasticsearch/mappings'
+            elastically_index_class_mapping:
+                my_index_name: \App\Model\MyModel
+            elastically_bulk_size: 100
+```
+
+### Using Messenger for async indexing
+
+Elastically ship a default Message and Handler for Symfony Messenger.
+
+Register the message in your configuration:
+
+```yaml
+framework:
+    messenger:
+        transports:
+            async: "%env(MESSENGER_TRANSPORT_DSN)%"
+
+        routing:
+            # async is whatever name you gave your transport above
+            'JoliCode\Elastically\Messenger\IndexationRequest':  async
+
+services:
+    App\Messenger\IndexationRequestHandler: ~
+```
+
+You have to implement `App\Messenger\IndexationRequestHandler` by extending the core `\JoliCode\Elastically\Messenger\IndexationRequestHandler` so you can plug your database or any other source of truth.
+
+Then from your code you have to call:
+
+```php
+use JoliCode\Elastically\Messenger\IndexationRequest;
+use JoliCode\Elastically\Messenger\IndexationRequestHandler;
+
+$bus->dispatch(new IndexationRequest(Product::class, '1234567890'));
+
+// Third argument is the operation, so for a delete:
+// new IndexationRequest(Product::class, 'ref9999', IndexationRequestHandler::OP_DELETE);
+```
+
+And then consume the messages:
+
+```sh
+$ php bin/console messenger:consume async
+```
+
+### Grouping IndexationRequest in a spool
+
+Sending multiple `IndexationRequest` during the same Symfony Request is not always appropriate, it will trigger multiple Bulk operations. Elastically provide a Kernel terminate listener to group all the `IndexationRequest` in a single `MultipleIndexationRequest` message.
+
+To use this mechanism, we send the simple `IndexationRequest` in a memory transport to be consumed and grouped in a really async transport:
+
+```yaml
+messenger:
+    transports:
+        async: "%env(MESSENGER_TRANSPORT_DSN)%"
+        queuing: 'in-memory:///'
+
+    routing:
+        'JoliCode\Elastically\Messenger\MultipleIndexationRequest': async
+        'JoliCode\Elastically\Messenger\IndexationRequest': queuing
+```
+
+You also need to register the event:
+
+```yaml
+services:
+    JoliCode\Elastically\Messenger\IndexationRequestSpoolSubscriber:
+        arguments:
+            - '@messenger.transport.queuing' # should be the name of the memory transport
+            - '@messenger.default_bus'
+        tags:
+            - { name: kernel.event_subscriber }
+```
+
 ## Using Jane for DTO and fast Normalizers
+
+:warning: See https://github.com/jolicode/elastically/issues/12 before.
 
 Install [JanePHP](https://jane.readthedocs.io/) and the model generator to build your own DTO and Normalizers. Then create your Serializer like this:
 
@@ -192,24 +281,6 @@ $client = new Client([
     Client::CONFIG_SERIALIZER => $serializer,
 ]);
 ```
-
-## Usage in Symfony
-
-Just declare the proper service in `services.yaml`:
-
-```yaml
-JoliCode\Elastically\Client:
-    arguments:
-        $config:
-            log: '%kernel.debug%'
-            host: '%env(ELASTICSEARCH_HOST)%'
-            elastically_mappings_directory: '%kernel.root_dir%/Elasticsearch/mappings'
-            elastically_index_class_mapping:
-                my_index_name: \App\Model\MyModel
-            elastically_bulk_size: 100
-```
-
-> todo, document the Messenger Handler usage.
 
 ## To be done
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ JoliCode\Elastically\Client:
             host: '%env(ELASTICSEARCH_HOST)%'
             elastically_mappings_directory: '%kernel.root_dir%/Elasticsearch/mappings'
             elastically_index_class_mapping:
-                my_index_name: \App\Model\MyModel
+                my_index_name: App\Model\MyModel
             elastically_bulk_size: 100
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ JoliCode\Elastically\Client:
 
 ### Using Messenger for async indexing
 
-Elastically ship a default Message and Handler for Symfony Messenger.
+Elastically ships with a default Message and Handler for Symfony Messenger.
 
 Register the message in your configuration:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Opinionated [Elastica](https://github.com/ruflin/Elastica) based framework to bo
 - Analysis is separated from mappings;
 - 100% compatibility with [ruflin/elastica](https://github.com/ruflin/Elastica);
 - Designed for Elasticsearch 7+ (no types), compatible with both ES 6 and ES 7;
+- Symfony Messenger Handler support;
 - Extra commands to monitor, update mapping, reindex... Commonly implemented tasks.
 
 ## Demo
@@ -207,6 +208,8 @@ JoliCode\Elastically\Client:
                 my_index_name: \App\Model\MyModel
             elastically_bulk_size: 100
 ```
+
+> todo, document the Messenger Handler usage.
 
 ## To be done
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
         "phpunit/phpunit": "^8",
-        "symfony/messenger": "^4.1|^5.0"
+        "symfony/messenger": "^4.3|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
         "phpunit/phpunit": "^8",
-        "symfony/messenger": "^4.3|^5.0"
+        "symfony/messenger": "^4.3|^5.0",
+        "symfony/framework-bundle": "^4.3|^5.0",
+        "symfony/http-foundation": "^4.3|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^8",
+        "symfony/messenger": "^4.1|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
         "phpunit/phpunit": "^8",
-        "symfony/messenger": "^4.3|^5.0",
+        "symfony/messenger": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/http-foundation": "^4.3|^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "php": "^7.2",
         "ext-json": "*",
         "ruflin/elastica": "^6.1",
-        "symfony/yaml": "^3.4|^4.0|^5.0",
-        "symfony/serializer": "^3.4|^4.0|^5.0",
         "symfony/property-access": "^3.4|^4.0|^5.0",
-        "symfony/property-info": "^3.4|^4.0|^5.0"
+        "symfony/property-info": "^3.4|^4.0|^5.0",
+        "symfony/serializer": "^3.4|^4.0|^5.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
@@ -42,5 +42,8 @@
         "psr-4": {
             "JoliCode\\Elastically\\Tests\\": "./tests"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,13 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^8",
+        "symfony/phpunit-bridge": "^5.0",
         "symfony/http-client": "^4.3|^5.0",
         "symfony/messenger": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0",
-        "symfony/http-foundation": "^4.3|^5.0"
+        "symfony/http-foundation": "^4.3|^5.0",
+        "symfony/browser-kit": "^4.3|^5.0",
+        "phpdocumentor/reflection-docblock": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" testdox="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Elastically tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="KERNEL_CLASS" value="JoliCode\Elastically\Tests\Symfony\TestKernel"/>
+    </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace JoliCode\Elastically;
 
 use Elastica\Client as ElasticaClient;
+use Elastica\Exception\RuntimeException;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
@@ -57,6 +58,18 @@ class Client extends ElasticaClient
         }
 
         return $name;
+    }
+
+    public function getIndexNameFromClass(string $className): string
+    {
+        $indexToClass = $this->getConfig(Client::CONFIG_INDEX_CLASS_MAPPING);
+        $indexName = array_search($className, $indexToClass, true);
+
+        if (!$indexName) {
+            throw new RuntimeException(sprintf('The given type (%s) does not exist in the configuration.', $className));
+        }
+
+        return $indexName;
     }
 
     public function getPureIndexName(string $fullIndexName): string

--- a/src/Messenger/IndexationRequest.php
+++ b/src/Messenger/IndexationRequest.php
@@ -2,19 +2,19 @@
 
 namespace JoliCode\Elastically\Messenger;
 
-final class IndexationRequest
+final class IndexationRequest implements IndexationRequestInterface
 {
     private $operation;
-    private $type;
+    private $className;
     private $id;
 
-    public function __construct(string $type, string $id, string $operation = IndexationRequestHandler::OP_INDEX)
+    public function __construct(string $className, string $id, string $operation = IndexationRequestHandler::OP_INDEX)
     {
         if (!in_array($operation, IndexationRequestHandler::OPERATIONS, true)) {
             throw new \InvalidArgumentException(sprintf('Not supported operation "%s" given.', $operation));
         }
 
-        $this->type = $type;
+        $this->className = $className;
         $this->id = $id;
         $this->operation = $operation;
     }
@@ -24,9 +24,9 @@ final class IndexationRequest
         return $this->operation;
     }
 
-    public function getType(): string
+    public function getClassName(): string
     {
-        return $this->type;
+        return $this->className;
     }
 
     public function getId(): string

--- a/src/Messenger/IndexationRequest.php
+++ b/src/Messenger/IndexationRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace JoliCode\Elastically\Messenger;
+
+final class IndexationRequest
+{
+    private $op;
+    private $type;
+    private $id;
+
+    public function __construct(string $type, string $id, string $op = IndexationRequestHandler::OP_INDEX)
+    {
+        if (!in_array($op, IndexationRequestHandler::OPS, true)) {
+            throw new \InvalidArgumentException(sprintf('Not supported operation "%s" given.', $op));
+        }
+
+        $this->type = $type;
+        $this->id = $id;
+        $this->op = $op;
+    }
+
+    public function getOp(): string
+    {
+        return $this->op;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Messenger/IndexationRequest.php
+++ b/src/Messenger/IndexationRequest.php
@@ -4,24 +4,24 @@ namespace JoliCode\Elastically\Messenger;
 
 final class IndexationRequest
 {
-    private $op;
+    private $operation;
     private $type;
     private $id;
 
-    public function __construct(string $type, string $id, string $op = IndexationRequestHandler::OP_INDEX)
+    public function __construct(string $type, string $id, string $operation = IndexationRequestHandler::OP_INDEX)
     {
-        if (!in_array($op, IndexationRequestHandler::OPS, true)) {
-            throw new \InvalidArgumentException(sprintf('Not supported operation "%s" given.', $op));
+        if (!in_array($operation, IndexationRequestHandler::OPERATIONS, true)) {
+            throw new \InvalidArgumentException(sprintf('Not supported operation "%s" given.', $operation));
         }
 
         $this->type = $type;
         $this->id = $id;
-        $this->op = $op;
+        $this->operation = $operation;
     }
 
-    public function getOp(): string
+    public function getOperation(): string
     {
-        return $this->op;
+        return $this->operation;
     }
 
     public function getType(): string

--- a/src/Messenger/IndexationRequestHandler.php
+++ b/src/Messenger/IndexationRequestHandler.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace JoliCode\Elastically\Messenger;
+
+use Elastica\Document;
+use JoliCode\Elastically\Client;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+abstract class IndexationRequestHandler implements MessageHandlerInterface
+{
+    const OP_INDEX = 'index';
+    const OP_DELETE = 'delete';
+    const OP_UPDATE = 'update';
+    const OP_CREATE = 'create';
+
+    const OPS = [
+        self::OP_INDEX,
+        self::OP_DELETE,
+        self::OP_UPDATE,
+        self::OP_CREATE,
+    ];
+
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+
+        // Disable the logs for memory concerns
+        $this->client->setLogger(new NullLogger());
+    }
+
+    public function __invoke(IndexationRequest $message)
+    {
+        $indexer = $this->client->getIndexer();
+        $indexToClass = $this->client->getConfig(Client::CONFIG_INDEX_CLASS_MAPPING);
+        $indexName = array_search($message->getType(), $indexToClass, true);
+
+        if (!$indexName) {
+            throw new UnrecoverableMessageHandlingException(sprintf('The given type (%s) does not exist!', $message->getType()));
+        }
+
+        if (self::OP_DELETE === $message->getOp()) {
+            $indexer->scheduleDelete($indexName, $message->getId());
+            $indexer->flush();
+
+            return;
+        }
+
+        $model = $this->fetchModel($message->getType(), $message->getId());
+
+        if (!$model) {
+            // ID does not exists, delete
+            $indexer->scheduleDelete($indexName, $message->getId());
+            $indexer->flush();
+
+            return;
+        }
+
+        switch ($message->getOp()) {
+            case self::OP_INDEX:
+                $indexer->scheduleIndex($indexName, new Document($message->getId(), $model, '_doc'));
+                break;
+            case self::OP_CREATE:
+                $indexer->scheduleCreate($indexName, new Document($message->getId(), $model, '_doc'));
+                break;
+            case self::OP_UPDATE:
+                $indexer->scheduleUpdate($indexName, new Document($message->getId(), $model, '_doc'));
+                break;
+        }
+
+        $indexer->flush();
+    }
+
+    /**
+     * Return a model (DTO) to send for indexation.
+     */
+    abstract public function fetchModel(string $type, string $id);
+}

--- a/src/Messenger/IndexationRequestHandler.php
+++ b/src/Messenger/IndexationRequestHandler.php
@@ -42,9 +42,7 @@ abstract class IndexationRequestHandler implements MessageHandlerInterface
             foreach ($message->getOperations() as $operation) {
                 $this->schedule($indexer, $operation);
             }
-        }
-
-        if ($message instanceof IndexationRequest) {
+        } elseif ($message instanceof IndexationRequest) {
             $this->schedule($indexer, $message);
         }
 

--- a/src/Messenger/IndexationRequestHandler.php
+++ b/src/Messenger/IndexationRequestHandler.php
@@ -56,7 +56,7 @@ abstract class IndexationRequestHandler implements MessageHandlerInterface
         $indexName = array_search($indexationRequest->getClassName(), $indexToClass, true);
 
         if (!$indexName) {
-            throw new UnrecoverableMessageHandlingException(sprintf('The given type (%s) does not exist!', $indexationRequest->getClassName()));
+            throw new UnrecoverableMessageHandlingException(sprintf('The given type (%s) does not exist.', $indexationRequest->getClassName()));
         }
 
         if (self::OP_DELETE === $indexationRequest->getOperation()) {

--- a/src/Messenger/IndexationRequestHandler.php
+++ b/src/Messenger/IndexationRequestHandler.php
@@ -63,24 +63,27 @@ abstract class IndexationRequestHandler implements MessageHandlerInterface
             return;
         }
 
-        $model = $this->fetchModel($indexationRequest->getClassName(), $indexationRequest->getId());
+        $document = $this->fetchDocument($indexationRequest->getClassName(), $indexationRequest->getId());
 
-        if (!$model) {
+        if (!$document) {
             // ID does not exists, delete
             $indexer->scheduleDelete($indexName, $indexationRequest->getId());
 
             return;
         }
 
+        $document->setType('_doc');
+        $document->setId($indexationRequest->getId());
+
         switch ($indexationRequest->getOperation()) {
             case self::OP_INDEX:
-                $indexer->scheduleIndex($indexName, new Document($indexationRequest->getId(), $model, '_doc'));
+                $indexer->scheduleIndex($indexName, $document);
                 break;
             case self::OP_CREATE:
-                $indexer->scheduleCreate($indexName, new Document($indexationRequest->getId(), $model, '_doc'));
+                $indexer->scheduleCreate($indexName, $document);
                 break;
             case self::OP_UPDATE:
-                $indexer->scheduleUpdate($indexName, new Document($indexationRequest->getId(), $model, '_doc'));
+                $indexer->scheduleUpdate($indexName, $document);
                 break;
         }
     }
@@ -88,5 +91,5 @@ abstract class IndexationRequestHandler implements MessageHandlerInterface
     /**
      * Return a model (DTO) to send for indexation.
      */
-    abstract public function fetchModel(string $className, string $id);
+    abstract public function fetchDocument(string $className, string $id): Document;
 }

--- a/src/Messenger/IndexationRequestHandler.php
+++ b/src/Messenger/IndexationRequestHandler.php
@@ -10,12 +10,12 @@ use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 abstract class IndexationRequestHandler implements MessageHandlerInterface
 {
-    const OP_INDEX = 'index';
-    const OP_DELETE = 'delete';
-    const OP_UPDATE = 'update';
-    const OP_CREATE = 'create';
+    public const OP_INDEX = 'index';
+    public const OP_DELETE = 'delete';
+    public const OP_UPDATE = 'update';
+    public const OP_CREATE = 'create';
 
-    const OPS = [
+    public const OPERATIONS = [
         self::OP_INDEX,
         self::OP_DELETE,
         self::OP_UPDATE,
@@ -42,7 +42,7 @@ abstract class IndexationRequestHandler implements MessageHandlerInterface
             throw new UnrecoverableMessageHandlingException(sprintf('The given type (%s) does not exist!', $message->getType()));
         }
 
-        if (self::OP_DELETE === $message->getOp()) {
+        if (self::OP_DELETE === $message->getOperation()) {
             $indexer->scheduleDelete($indexName, $message->getId());
             $indexer->flush();
 
@@ -59,7 +59,7 @@ abstract class IndexationRequestHandler implements MessageHandlerInterface
             return;
         }
 
-        switch ($message->getOp()) {
+        switch ($message->getOperation()) {
             case self::OP_INDEX:
                 $indexer->scheduleIndex($indexName, new Document($message->getId(), $model, '_doc'));
                 break;

--- a/src/Messenger/IndexationRequestInterface.php
+++ b/src/Messenger/IndexationRequestInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JoliCode\Elastically\Messenger;
+
+interface IndexationRequestInterface
+{
+}

--- a/src/Messenger/IndexationRequestSpoolSubscriber.php
+++ b/src/Messenger/IndexationRequestSpoolSubscriber.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace JoliCode\Elastically\Messenger;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * Same idea as https://github.com/symfony/swiftmailer-bundle/blob/master/EventListener/EmailSenderListener.php.
+ */
+class IndexationRequestSpoolSubscriber implements EventSubscriberInterface
+{
+    private $logger;
+
+    private $wasExceptionThrown = false;
+
+    private $singleTransport;
+
+    private $bus;
+
+    public function __construct(TransportInterface $singleTransport, MessageBusInterface $bus, LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+        $this->singleTransport = $singleTransport;
+        $this->bus = $bus;
+    }
+
+    public function onException()
+    {
+        $this->wasExceptionThrown = true;
+    }
+
+    public function onTerminate()
+    {
+        $operations = [];
+
+        foreach ($this->singleTransport->get() as $envelope) {
+            $operations[] = $envelope->getMessage();
+
+            $this->singleTransport->ack($envelope);
+        }
+
+        if (empty($operations)) {
+            return;
+        }
+
+        $message = new MultipleIndexationRequest($operations);
+        $this->bus->dispatch($message);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        $listeners = [
+            KernelEvents::EXCEPTION => 'onException',
+            KernelEvents::TERMINATE => 'onTerminate',
+            ConsoleEvents::ERROR => 'onException',
+            ConsoleEvents::TERMINATE => 'onTerminate',
+        ];
+
+        return $listeners;
+    }
+
+    public function reset()
+    {
+        $this->wasExceptionThrown = false;
+    }
+}

--- a/src/Messenger/IndexationRequestSpoolSubscriber.php
+++ b/src/Messenger/IndexationRequestSpoolSubscriber.php
@@ -70,7 +70,7 @@ class IndexationRequestSpoolSubscriber implements EventSubscriberInterface
     {
         $listeners = [
             KernelEvents::EXCEPTION => 'onException',
-            KernelEvents::RESPONSE => 'onResponse',
+            KernelEvents::RESPONSE => ['onResponse', -10],
             ConsoleEvents::ERROR => 'onException',
             ConsoleEvents::TERMINATE => 'onTerminate',
         ];

--- a/src/Messenger/IndexationRequestSpoolSubscriber.php
+++ b/src/Messenger/IndexationRequestSpoolSubscriber.php
@@ -5,6 +5,7 @@ namespace JoliCode\Elastically\Messenger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -56,11 +57,20 @@ class IndexationRequestSpoolSubscriber implements EventSubscriberInterface
         $this->bus->dispatch($message);
     }
 
+    public function onResponse(ResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $this->onTerminate();
+    }
+
     public static function getSubscribedEvents()
     {
         $listeners = [
             KernelEvents::EXCEPTION => 'onException',
-            KernelEvents::TERMINATE => 'onTerminate',
+            KernelEvents::RESPONSE => 'onReponse',
             ConsoleEvents::ERROR => 'onException',
             ConsoleEvents::TERMINATE => 'onTerminate',
         ];

--- a/src/Messenger/IndexationRequestSpoolSubscriber.php
+++ b/src/Messenger/IndexationRequestSpoolSubscriber.php
@@ -36,6 +36,10 @@ class IndexationRequestSpoolSubscriber implements EventSubscriberInterface
 
     public function onTerminate()
     {
+        if ($this->wasExceptionThrown) {
+            return;
+        }
+
         $operations = [];
 
         foreach ($this->singleTransport->get() as $envelope) {

--- a/src/Messenger/IndexationRequestSpoolSubscriber.php
+++ b/src/Messenger/IndexationRequestSpoolSubscriber.php
@@ -9,11 +9,12 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Same idea as https://github.com/symfony/swiftmailer-bundle/blob/master/EventListener/EmailSenderListener.php.
  */
-class IndexationRequestSpoolSubscriber implements EventSubscriberInterface
+class IndexationRequestSpoolSubscriber implements EventSubscriberInterface, ResetInterface
 {
     private $logger;
 

--- a/src/Messenger/IndexationRequestSpoolSubscriber.php
+++ b/src/Messenger/IndexationRequestSpoolSubscriber.php
@@ -70,7 +70,7 @@ class IndexationRequestSpoolSubscriber implements EventSubscriberInterface
     {
         $listeners = [
             KernelEvents::EXCEPTION => 'onException',
-            KernelEvents::RESPONSE => 'onReponse',
+            KernelEvents::RESPONSE => 'onResponse',
             ConsoleEvents::ERROR => 'onException',
             ConsoleEvents::TERMINATE => 'onTerminate',
         ];

--- a/src/Messenger/MultipleIndexationRequest.php
+++ b/src/Messenger/MultipleIndexationRequest.php
@@ -6,7 +6,7 @@ final class MultipleIndexationRequest implements IndexationRequestInterface
 {
     private $operations = [];
 
-    public function __construct($operations)
+    public function __construct(array $operations)
     {
         $this->operations = $operations;
     }

--- a/src/Messenger/MultipleIndexationRequest.php
+++ b/src/Messenger/MultipleIndexationRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace JoliCode\Elastically\Messenger;
+
+final class MultipleIndexationRequest implements IndexationRequestInterface
+{
+    private $operations = [];
+
+    public function __construct($operations)
+    {
+        $this->operations = $operations;
+    }
+
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests;
+
+use Elastica\Exception\RuntimeException;
+use JoliCode\Elastically\Client;
+
+final class ClientTest extends BaseTestCase
+{
+    public function testClientIndexNameFromClass(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $client = new Client([
+            Client::CONFIG_INDEX_CLASS_MAPPING => [
+                'todo' => TestDTO::class,
+            ],
+        ]);
+
+        $client->getIndexNameFromClass('OLA');
+    }
+
+    public function testIndexNameFromClassWithBackslashes(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $client = new Client([
+            Client::CONFIG_INDEX_CLASS_MAPPING => [
+                'todo' => '\\'.TestDTO::class,
+            ],
+        ]);
+
+        $client->getIndexNameFromClass(TestDTO::class);
+    }
+}

--- a/tests/Messenger/IndexationRequestHandlerTest.php
+++ b/tests/Messenger/IndexationRequestHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JoliCode\Elastically\Tests\Messenger;
 
+use Elastica\Document;
 use JoliCode\Elastically\Client;
 use JoliCode\Elastically\Messenger\IndexationRequest;
 use JoliCode\Elastically\Messenger\IndexationRequestHandler;
@@ -80,12 +81,12 @@ class TestDTO
 
 class TestHandler extends IndexationRequestHandler
 {
-    public function fetchModel(string $className, string $id)
+    public function fetchDocument(string $className, string $id): Document
     {
         $dto = new TestDTO();
         $dto->bar = 'todo';
         $dto->foo = $id;
 
-        return $dto;
+        return new Document($id, $dto);
     }
 }

--- a/tests/Messenger/IndexationRequestHandlerTest.php
+++ b/tests/Messenger/IndexationRequestHandlerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Messenger;
+
+use JoliCode\Elastically\Client;
+use JoliCode\Elastically\Messenger\IndexationRequest;
+use JoliCode\Elastically\Messenger\IndexationRequestHandler;
+use JoliCode\Elastically\ResultSet;
+use JoliCode\Elastically\Tests\BaseTestCase;
+
+final class IndexationRequestHandlerTest extends BaseTestCase
+{
+    public function testDocumentAreIndexed(): void
+    {
+        $indexName = mb_strtolower(__FUNCTION__);
+
+        $client = $this->getClient();
+        $client->setConfigValue(Client::CONFIG_INDEX_CLASS_MAPPING, [
+            $indexName => TestDTO::class,
+        ]);
+
+        $handler = new TestHandler($client);
+        $handler(new IndexationRequest(TestDTO::class, '1234567890'));
+        $handler(new IndexationRequest(TestDTO::class, '1234567890', IndexationRequestHandler::OP_UPDATE));
+        $handler(new IndexationRequest(TestDTO::class, 'ref7777', IndexationRequestHandler::OP_CREATE));
+        $handler(new IndexationRequest(TestDTO::class, 'ref8888', IndexationRequestHandler::OP_INDEX));
+        $handler(new IndexationRequest(TestDTO::class, 'ref9999', IndexationRequestHandler::OP_DELETE));
+
+        $index = $client->getIndex($indexName);
+        $index->refresh();
+
+        $resultSet = $index->search();
+
+        $this->assertInstanceOf(ResultSet::class, $resultSet);
+        $this->assertEquals(3, $resultSet->getTotalHits());
+
+        $this->assertInstanceOf(TestDTO::class, $index->getModel('1234567890'));
+        $this->assertInstanceOf(TestDTO::class, $index->getModel('ref7777'));
+        $this->assertInstanceOf(TestDTO::class, $index->getModel('ref8888'));
+    }
+}
+
+class TestDTO
+{
+    public $foo;
+    public $bar;
+}
+
+class TestHandler extends IndexationRequestHandler
+{
+    public function fetchModel(string $type, string $id)
+    {
+        $dto = new TestDTO();
+        $dto->bar = 'todo';
+        $dto->foo = $id;
+
+        return $dto;
+    }
+}

--- a/tests/Messenger/MemoryQueuingFunctionalTest.php
+++ b/tests/Messenger/MemoryQueuingFunctionalTest.php
@@ -6,7 +6,6 @@ namespace JoliCode\Elastically\Tests\Messenger;
 
 use JoliCode\Elastically\Messenger\IndexationRequest;
 use JoliCode\Elastically\Messenger\MultipleIndexationRequest;
-use JoliCode\Elastically\Tests\Symfony\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,8 +21,6 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
 {
     public function testFrameworkQueue(): void
     {
-        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
-
         static::bootKernel(['debug' => false]);
 
         /* @var InMemoryTransport $transport */
@@ -33,8 +30,6 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
 
     public function testFrameworkKernelTerminateResend(): void
     {
-        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
-
         static::bootKernel(['debug' => false]);
 
         /* @var MessageBus $bus */
@@ -78,8 +73,6 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
 
     public function testFrameworkKernelTerminateWithNoMessage(): void
     {
-        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
-
         static::bootKernel(['debug' => false]);
 
         /* @var MessageBus $bus */

--- a/tests/Messenger/MemoryQueuingFunctionalTest.php
+++ b/tests/Messenger/MemoryQueuingFunctionalTest.php
@@ -11,7 +11,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
@@ -52,8 +53,11 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
         /* @var EventDispatcher $dispatcher */
         $dispatcher = self::$container->get('event_dispatcher');
 
-        // Simulate Kernel Terminate
-        $dispatcher->dispatch(new TerminateEvent(static::$kernel, new Request(), new Response()), KernelEvents::TERMINATE);
+        // Simulate Kernel Response
+        $dispatcher->dispatch(
+            new ResponseEvent(static::$kernel, new Request(), Kernel::MASTER_REQUEST, new Response()),
+            KernelEvents::RESPONSE
+        );
 
         $this->assertCount(3, $transport->getAcknowledged());
         $this->assertEmpty($transport->getRejected());
@@ -88,8 +92,11 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
         /* @var EventDispatcher $dispatcher */
         $dispatcher = self::$container->get('event_dispatcher');
 
-        // Simulate Kernel Terminate
-        $dispatcher->dispatch(new TerminateEvent(static::$kernel, new Request(), new Response()), KernelEvents::TERMINATE);
+        // Simulate Kernel Response
+        $dispatcher->dispatch(
+            new ResponseEvent(static::$kernel, new Request(), Kernel::MASTER_REQUEST, new Response()),
+            KernelEvents::RESPONSE
+        );
 
         $this->assertCount(0, $transport->getAcknowledged());
 

--- a/tests/Messenger/MemoryQueuingFunctionalTest.php
+++ b/tests/Messenger/MemoryQueuingFunctionalTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Messenger;
+
+use JoliCode\Elastically\Messenger\IndexationRequest;
+use JoliCode\Elastically\Messenger\MultipleIndexationRequest;
+use JoliCode\Elastically\Tests\Symfony\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+final class MemoryQueuingFunctionalTest extends KernelTestCase
+{
+    public function testFrameworkQueue(): void
+    {
+        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
+
+        static::bootKernel(['debug' => false]);
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.queuing.test');
+        $this->assertCount(0, $transport->getSent());
+    }
+
+    public function testFrameworkKernelTerminateResend(): void
+    {
+        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
+
+        static::bootKernel(['debug' => false]);
+
+        /* @var MessageBus $bus */
+        $bus = self::$container->get('messenger.default_bus');
+
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567890'));
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567891'));
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567892'));
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.queuing.test');
+        $this->assertCount(3, $transport->getSent());
+        $this->assertEmpty($transport->getAcknowledged());
+        $this->assertEmpty($transport->getRejected());
+
+        /* @var EventDispatcher $dispatcher */
+        $dispatcher = self::$container->get('event_dispatcher');
+
+        // Simulate Kernel Terminate
+        $dispatcher->dispatch(new TerminateEvent(static::$kernel, new Request(), new Response()), KernelEvents::TERMINATE);
+
+        $this->assertCount(3, $transport->getAcknowledged());
+        $this->assertEmpty($transport->getRejected());
+
+        /* @var InMemoryTransport $transportBulk */
+        $transportBulk = self::$container->get('messenger.transport.async.test');
+        $this->assertCount(1, $transportBulk->getSent());
+        $this->assertEmpty($transportBulk->getAcknowledged());
+        $this->assertEmpty($transportBulk->getRejected());
+
+        $message = $transportBulk->get();
+        $this->assertCount(1, $message);
+        $message = reset($message);
+        /* @var Envelope $message */
+        $this->assertInstanceOf(MultipleIndexationRequest::class, $message->getMessage());
+        $this->assertCount(3, $message->getMessage()->getOperations());
+    }
+
+    public function testFrameworkKernelTerminateWithNoMessage(): void
+    {
+        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
+
+        static::bootKernel(['debug' => false]);
+
+        /* @var MessageBus $bus */
+        $bus = self::$container->get('messenger.default_bus');
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.queuing.test');
+        $this->assertCount(0, $transport->getSent());
+
+        /* @var EventDispatcher $dispatcher */
+        $dispatcher = self::$container->get('event_dispatcher');
+
+        // Simulate Kernel Terminate
+        $dispatcher->dispatch(new TerminateEvent(static::$kernel, new Request(), new Response()), KernelEvents::TERMINATE);
+
+        $this->assertCount(0, $transport->getAcknowledged());
+
+        /* @var InMemoryTransport $transportBulk */
+        $transportBulk = self::$container->get('messenger.transport.async.test');
+        $this->assertCount(0, $transportBulk->getSent());
+    }
+}

--- a/tests/Messenger/TestControllerFunctionalTest.php
+++ b/tests/Messenger/TestControllerFunctionalTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Messenger;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+final class TestControllerFunctionalTest extends WebTestCase
+{
+    public function testControllerWithException(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/with_exception');
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.queuing.test');
+        $this->assertCount(2, $transport->getSent());
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.async.test');
+        $this->assertCount(0, $transport->getSent());
+
+        $this->assertSame(500, $client->getResponse()->getStatusCode());
+    }
+
+    public function testControllerWithResponse(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/with_response');
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.queuing.test');
+        $this->assertCount(2, $transport->getSent());
+        $this->assertCount(2, $transport->getAcknowledged());
+
+        /* @var InMemoryTransport $transport */
+        $transport = self::$container->get('messenger.transport.async.test');
+        $this->assertCount(1, $transport->getSent());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Symfony/TestController.php
+++ b/tests/Symfony/TestController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Symfony;
+
+use JoliCode\Elastically\Messenger\IndexationRequest;
+use JoliCode\Elastically\Tests\Messenger\TestDTO;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class TestController extends AbstractController
+{
+    public function withException(MessageBusInterface $bus)
+    {
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567890'));
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567891'));
+
+        throw new \RuntimeException('My big error.');
+    }
+
+    public function withResponse(MessageBusInterface $bus)
+    {
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567890'));
+        $bus->dispatch(new IndexationRequest(TestDTO::class, '1234567891'));
+
+        return new Response('Everything is fine.', Response::HTTP_OK);
+    }
+}

--- a/tests/Symfony/TestKernel.php
+++ b/tests/Symfony/TestKernel.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = [
+            new FrameworkBundle(),
+        ];
+
+        return $bundles;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config.yaml');
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir();
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir();
+    }
+}

--- a/tests/Symfony/TestKernel.php
+++ b/tests/Symfony/TestKernel.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace JoliCode\Elastically\Tests\Symfony;
 
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 class TestKernel extends Kernel
 {
+    use MicroKernelTrait;
+
     public function registerBundles()
     {
         $bundles = [
@@ -19,18 +24,28 @@ class TestKernel extends Kernel
         return $bundles;
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
         $loader->load(__DIR__.'/config.yaml');
+
+        $def = $c->register(TestController::class);
+        $def->setAutowired(true);
+        $def->setAutoconfigured(true);
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $routes->add('/with_exception', TestController::class.'::withException', 'with_exception');
+        $routes->add('/with_response', TestController::class.'::withResponse', 'with_response');
     }
 
     public function getCacheDir()
     {
-        return sys_get_temp_dir();
+        return sys_get_temp_dir().DIRECTORY_SEPARATOR.'elastically';
     }
 
     public function getLogDir()
     {
-        return sys_get_temp_dir();
+        return sys_get_temp_dir().DIRECTORY_SEPARATOR.'elastically_logs';
     }
 }

--- a/tests/Symfony/config.yaml
+++ b/tests/Symfony/config.yaml
@@ -1,0 +1,53 @@
+# Old style, all the config in one place.
+
+framework:
+    secret: 'Bloubigoulba'
+    php_errors:
+        log: true
+    messenger:
+        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
+        # failure_transport: failed
+
+        transports:
+            async: 'in-memory:///' # Should be a real async transport. For testing we cheat.
+            queuing: 'in-memory:///'
+
+        routing:
+            'JoliCode\Elastically\Messenger\MultipleIndexationRequest': async
+            'JoliCode\Elastically\Messenger\IndexationRequest': queuing
+
+services:
+    _defaults:
+        public: true
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    messenger.transport.queuing.test:
+        public: true
+        alias: messenger.transport.queuing
+
+    messenger.transport.async.test:
+        public: true
+        alias: messenger.transport.async
+
+    dummy:
+        class: \stdClass
+        arguments:
+            - '@Symfony\Component\Messenger\MessageBusInterface'
+
+    JoliCode\Elastically\Client:
+        arguments:
+            $config:
+                log: '%kernel.debug%'
+                host: 'localhost'
+                elastically_mappings_directory: '%kernel.project_dir%/configs_analysis'
+                elastically_index_class_mapping:
+                    hop: \JoliCode\Elastically\Tests\Messenger\TestDTO
+                elastically_bulk_size: 100
+
+    JoliCode\Elastically\Messenger\IndexationRequestSpoolSubscriber:
+        arguments:
+            - '@messenger.transport.queuing'
+            - '@messenger.default_bus'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/tests/Symfony/config.yaml
+++ b/tests/Symfony/config.yaml
@@ -1,6 +1,7 @@
 # Old style, all the config in one place.
 
 framework:
+    test: true
     secret: 'Bloubigoulba'
     php_errors:
         log: true

--- a/tests/Symfony/config.yaml
+++ b/tests/Symfony/config.yaml
@@ -42,7 +42,7 @@ services:
                 host: 'localhost'
                 elastically_mappings_directory: '%kernel.project_dir%/configs_analysis'
                 elastically_index_class_mapping:
-                    hop: \JoliCode\Elastically\Tests\Messenger\TestDTO
+                    hop: JoliCode\Elastically\Tests\Messenger\TestDTO
                 elastically_bulk_size: 100
 
     JoliCode\Elastically\Messenger\IndexationRequestSpoolSubscriber:


### PR DESCRIPTION
Symfony Messenger is really simple to use. In this pull request I just add the basic of handling indexation request via Messenger. 

There is a simple DTO, the provided handler must be overwritten to implement the fetchModel method, then I call the proper methods on the Indexer.

I use a very close version of this in production already :yum: 