### PR TITLE
Check candidate index name suffix before purge it

### DIFF
--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -97,7 +97,14 @@ class IndexBuilder
                 continue;
             }
 
-            $date = \DateTime::createFromFormat('Y-m-d-His', str_replace($indexName.'_', '', $realIndexName));
+            // Check suffix (it must contains a valid date)
+            $indexSuffixName = substr($realIndexName, strlen($indexName) + 1);
+            $date = \DateTime::createFromFormat('Y-m-d-His', $indexSuffixName);
+            if (!$date) {
+                unset($indexes[$realIndexName]);
+                continue;
+            }
+
             $data['date'] = $date;
             $data['is_live'] = false !== array_search($indexName, $data['aliases']);
         }

--- a/tests/IndexBuilderTest.php
+++ b/tests/IndexBuilderTest.php
@@ -169,4 +169,21 @@ final class IndexBuilderTest extends BaseTestCase
             $this->assertStringContainsStringIgnoringCase('closed', $e->getMessage());
         }
     }
+
+    public function testPurgerDistinguishesIndicesWithTheSamePrefix(): void
+    {
+        $indexBuilder = $this->getIndexBuilder(__DIR__.'/configs_analysis');
+
+        $indexFooBar = $indexBuilder->createIndex('foo_bar');
+        $indexBuilder->markAsLive($indexFooBar, 'foo_bar');
+
+        usleep(1200000); // 1,2 second
+
+        $indexFoo = $indexBuilder->createIndex('foo');
+        $indexBuilder->markAsLive($indexFoo, 'foo');
+
+        $operations = $indexBuilder->purgeOldIndices('foo');
+
+        $this->assertCount(0, $operations);
+    }
 }

--- a/tests/configs_analysis/foo_bar_mapping.yaml
+++ b/tests/configs_analysis/foo_bar_mapping.yaml
@@ -1,0 +1,4 @@
+mappings:
+    properties:
+        name:
+            type: text

--- a/tests/configs_analysis/foo_mapping.yaml
+++ b/tests/configs_analysis/foo_mapping.yaml
@@ -1,0 +1,4 @@
+mappings:
+    properties:
+        name:
+            type: text


### PR DESCRIPTION
This PR is an attempt to fix #24

With this fix the `IndexBuilder->purgeOldIndices()` will skip purging indices which their suffix isn't a valid date time.

---

To think about: Should it relays only on the index name? Why not track the "public" name and created date in the index metadata?