### PR TITLE
Add tests for Jane JSON Schema 6.x, allow fast DTO In and Out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.phpunit.result.cache
 /composer.lock
 /vendor/
+/tests/Jane/generated/*
+!/tests/Jane/generated/.gitkeep
+.php_cs.cache

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $indexBuilder->markAsLive($index, 'beers');
 $indexBuilder->purgeOldIndices('beers');
 ```
 
-*configs/beers_mapping.yaml*
+*mappings/beers_mapping.yaml*
 
 ```yaml
 # Anything you want, no validation

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use Elastica\Document;
 // New Client object with new options
 $client = new Client([
     // Where to find the mappings
-    Client::CONFIG_MAPPINGS_DIRECTORY => __DIR__.'/configs',
+    Client::CONFIG_MAPPINGS_DIRECTORY => __DIR__.'/mappings',
     // What object to find in each index
     Client::CONFIG_INDEX_CLASS_MAPPING => [
         'beers' => Beer::class,    
@@ -276,27 +276,17 @@ services:
             - { name: kernel.event_subscriber }
 ```
 
-## Using Jane for DTO and fast Normalizers
+## Using Jane to build PHP DTO and fast Normalizers
 
-:warning: See https://github.com/jolicode/elastically/issues/12 before.
-
-Install [JanePHP](https://jane.readthedocs.io/) and the model generator to build your own DTO and Normalizers. Then create your Serializer like this:
+Install [JanePHP](https://jane.readthedocs.io/) json-schema tools to build your own DTO and Normalizers. All you have to do is setting the Jane-completed Serializer on the Client:
 
 ```php
-$normalizers = \Elasticsearch\Normalizer\NormalizerFactory::create();
-$encoders = [
-    new JsonEncoder(
-       new JsonEncode([JsonEncode::OPTIONS => \JSON_UNESCAPED_SLASHES]),
-       new JsonDecode([JsonDecode::ASSOCIATIVE => false])
-    )
-];
-
-$serializer = new Serializer($normalizers, $encoders);
-
 $client = new Client([
     Client::CONFIG_SERIALIZER => $serializer,
 ]);
 ```
+
+_[Not compatible with Jane < 6](https://github.com/jolicode/elastically/issues/12)._
 
 ## To be done
 

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,15 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/http-client": "^4.3|^5.0",
-        "symfony/messenger": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.3|^5.0",
-        "symfony/http-foundation": "^4.3|^5.0",
+        "jane-php/json-schema": "^6.0",
+        "jane-php/json-schema-runtime": "^6.0",
+        "phpdocumentor/reflection-docblock": "^4.3",
         "symfony/browser-kit": "^4.3|^5.0",
-        "phpdocumentor/reflection-docblock": "^4.3"
+        "symfony/framework-bundle": "^4.3|^5.0",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/http-foundation": "^4.3|^5.0",
+        "symfony/messenger": "^4.4|^5.0",
+        "symfony/phpunit-bridge": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Jane/JaneTest.php
+++ b/tests/Jane/JaneTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\Elastically\Tests\Jane;
+
+use Elastica\Document;
+use Jane\JsonSchema\Console\Command\GenerateCommand;
+use Jane\JsonSchema\Console\Loader\ConfigLoader;
+use Jane\JsonSchema\Console\Loader\SchemaLoader;
+use JoliCode\Elastically\Client;
+use JoliCode\Elastically\Tests\Jane\generated\Model\MyModel;
+use JoliCode\Elastically\Tests\Jane\generated\Model\MyModelIngredientsItemAnyOf;
+use JoliCode\Elastically\Tests\Jane\generated\Normalizer\JaneObjectNormalizer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class JaneTest extends TestCase
+{
+    public function testCreateIndexAndSearchWithJaneObject()
+    {
+        // Build the models
+        $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader());
+        $inputArray = new ArrayInput([
+            '--config-file' => __DIR__.'/jane-config.php',
+        ], $command->getDefinition());
+
+        $command->execute($inputArray, new NullOutput());
+
+        // Build the Serializer
+        $normalizers = [
+            new ArrayDenormalizer(),
+            new JaneObjectNormalizer(),
+        ];
+        $encoders = [new JsonEncoder(
+            new JsonEncode(),
+            new JsonDecode([JsonDecode::ASSOCIATIVE => true])),
+        ];
+
+        $serializer = new Serializer($normalizers, $encoders);
+
+        // Build Elastically Client
+        $elastically = new Client([
+            Client::CONFIG_MAPPINGS_DIRECTORY => __DIR__.'/../configs',
+            Client::CONFIG_INDEX_CLASS_MAPPING => [
+                'beers' => MyModel::class,
+            ],
+            Client::CONFIG_SERIALIZER => $serializer,
+        ]);
+
+        // Build Index
+        $indexBuilder = $elastically->getIndexBuilder();
+        $index = $indexBuilder->createIndex('beers');
+        $indexBuilder->markAsLive($index, 'beers');
+
+        // Create a DTO
+        $dto = new MyModel();
+        $dto->setName('La Montreuilloise Smoked Porter');
+        $dto->setPrice(3.20);
+        $ingredient1 = new MyModelIngredientsItemAnyOf();
+        $ingredient1->setName('Water');
+        $ingredient2 = new MyModelIngredientsItemAnyOf();
+        $ingredient2->setName('Malt');
+        $ingredient3 = new MyModelIngredientsItemAnyOf();
+        $ingredient3->setName('Hops');
+        $dto->setIngredients([$ingredient1, $ingredient2, $ingredient3]);
+
+        // Index the DTO
+        $indexer = $elastically->getIndexer();
+        $indexer->scheduleIndex('beers', new Document('123', $dto));
+        $indexer->flush();
+        $indexer->refresh('beers');
+
+        // Search
+        $results = $elastically->getIndex('beers')->search();
+
+        $this->assertInstanceOf(MyModel::class, $results->getResults()[0]->getModel());
+
+        $elasticallyDto = $results->getResults()[0]->getModel();
+
+        // DTO are not the same object but are identical
+        $this->assertNotSame($dto, $elasticallyDto);
+        $this->assertEquals($dto, $elasticallyDto);
+    }
+}

--- a/tests/Jane/jane-config.php
+++ b/tests/Jane/jane-config.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__.'/schema.json',
+    'root-class' => 'MyModel',
+    'namespace' => 'JoliCode\Elastically\Tests\Jane\generated',
+    'directory' => __DIR__.'/generated',
+    'clean-generated' => false,
+];

--- a/tests/Jane/schema.json
+++ b/tests/Jane/schema.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "title": "The root schema",
+    "description": "The root schema comprises the entire JSON document.",
+    "default": {},
+    "required": [
+        "name",
+        "price",
+        "ingredients"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "name": {
+            "$id": "#/properties/name",
+            "type": "string",
+            "title": "The name schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "Smoked"
+            ]
+        },
+        "price": {
+            "$id": "#/properties/price",
+            "type": "number",
+            "title": "The price schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0,
+            "examples": [
+                12.5
+            ]
+        },
+        "ingredients": {
+            "$id": "#/properties/ingredients",
+            "type": "array",
+            "title": "The ingredients schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": [],
+            "examples": [
+                [
+                    {
+                        "name": "malt"
+                    },
+                    {
+                        "name": "hops"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/ingredients/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/ingredients/items/anyOf/0",
+                        "type": "object",
+                        "title": "The first anyOf schema",
+                        "description": "An explanation about the purpose of this instance.",
+                        "default": {},
+                        "examples": [
+                            {
+                                "name": "malt"
+                            }
+                        ],
+                        "required": [
+                            "name"
+                        ],
+                        "additionalProperties": true,
+                        "properties": {
+                            "name": {
+                                "$id": "#/properties/ingredients/items/anyOf/0/properties/name",
+                                "type": "string",
+                                "title": "The name schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": "",
+                                "examples": [
+                                    "malt"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Jane 6.0 fixes #12, which is great news.

This PR adds tests for Jane support by building a schema and using the DTO for Indexing and Search.