### PR TITLE
Add the migrate command to upgrade the mapping of existing indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ $indexBuilder->markAsLive($index, 'beers');
 
 // Clean the old indices (close the previous one and delete the older)
 $indexBuilder->purgeOldIndices('beers');
+
+// Mapping change? Just call migrate and enjoy a full reindex (use the Task API internally to avoid timeout)
+$newIndex = $indexBuilder->migrate($index);
+$indexBuilder->speedUpRefresh($newIndex);
+$indexBuilder->markAsLive($newIndex, 'beers');
 ```
 
 *mappings/beers_mapping.yaml*

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,7 +46,6 @@ class Client extends ElasticaClient
     /**
      * The type hint here is wrong on purpose, to allow PHP 7.2.
      *
-     * @param string $name
      * @return Index
      */
     public function getIndex(string $name): \Elastica\Index

--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -5,6 +5,7 @@ namespace JoliCode\Elastically;
 use Elastica\Exception\InvalidException;
 use Elastica\Exception\RuntimeException;
 use Elastica\Index;
+use Elastica\Reindex;
 use Elastica\Request;
 use Elastica\Response;
 use Elasticsearch\Endpoints\Cluster\State;
@@ -59,9 +60,6 @@ class IndexBuilder
         return $this->client->request('_aliases', Request::POST, $data);
     }
 
-    /**
-     * @todo add tests
-     */
     public function slowDownRefresh(Index $index): void
     {
         $index->getSettings()->setRefreshInterval('60s');
@@ -74,8 +72,11 @@ class IndexBuilder
 
     public function migrate(Index $current, Index $new)
     {
-        // @todo Waiting for https://github.com/ruflin/Elastica/pull/1637 to be merged
-        // This method should use the TASK API, because we do not want to WAIT for the reindex (HTTP Timeout issues).
+        $reindex = new Reindex($current, $new);
+        $reindex->setWaitForCompletion(Reindex::WAIT_FOR_COMPLETION_FALSE);
+
+        // @todo implement the wait
+        return $reindex->run();
     }
 
     public function purgeOldIndices(string $indexName): array

--- a/tests/IndexBuilderTest.php
+++ b/tests/IndexBuilderTest.php
@@ -206,7 +206,7 @@ final class IndexBuilderTest extends BaseTestCase
 
     public function testMigrate(): void
     {
-        $indexName = mb_strtolower(__FUNCTION__);
+        $indexName = 'empty';
 
         $dto = new MigrateDTO();
         $dto->bar = 'I like unicorns.';
@@ -223,9 +223,8 @@ final class IndexBuilderTest extends BaseTestCase
         $this->assertInstanceOf(Document::class, $document);
 
         $indexBuilder = $this->getIndexBuilder(__DIR__.'/configs');
-        $newIndex = $indexBuilder->createIndex('empty');
 
-        $indexBuilder->migrate($client->getIndex($indexName), $newIndex);
+        $newIndex = $indexBuilder->migrate($client->getIndex($indexName));
         $indexer->refresh($newIndex);
 
         $document = $newIndex->getDocument('f');


### PR DESCRIPTION
Built on top of @nicolassing work in https://github.com/jolicode/elastically/pull/19

This add a new "migrate" method allowing to upgrade mapping on live indexes.