### PR TITLE
Use kernel.project_dir instead of kernel.root_dir in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ JoliCode\Elastically\Client:
     arguments:
         $config:
             host: '%env(ELASTICSEARCH_HOST)%'
-            elastically_mappings_directory: '%kernel.root_dir%/Elasticsearch/mappings'
+            elastically_mappings_directory: '%kernel.project_dir%/Elasticsearch/mappings'
             elastically_index_class_mapping:
                 my_index_name: App\Model\MyModel
             elastically_serializer: '@serializer'


### PR DESCRIPTION
kernel.root_dir is deprecated since Symfony 4.2

see https://symfony.com/blog/new-in-symfony-4-2-important-deprecations