### PR TITLE
Add optional fileName parameter to specify an index file name

### DIFF
--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -24,8 +24,8 @@ class IndexBuilder
 
     public function createIndex($indexName, $fileName = null): Index
     {
-        $fileName = $fileName ?? $indexName;
-        $mappingFilePath = $this->configurationDirectory.DIRECTORY_SEPARATOR.$fileName.'_mapping.yaml';
+        $fileName = $fileName ?? ($indexName.'_mapping.yaml');
+        $mappingFilePath = $this->configurationDirectory.DIRECTORY_SEPARATOR.$fileName;
         if (!is_file($mappingFilePath)) {
             throw new InvalidException(sprintf('Mapping file "%s" not found.', $mappingFilePath));
         }

--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -22,9 +22,10 @@ class IndexBuilder
         $this->configurationDirectory = $configurationDirectory;
     }
 
-    public function createIndex($indexName): Index
+    public function createIndex($indexName, $fileName = null): Index
     {
-        $mappingFilePath = $this->configurationDirectory.DIRECTORY_SEPARATOR.$indexName.'_mapping.yaml';
+        $fileName = $fileName ?? $indexName;
+        $mappingFilePath = $this->configurationDirectory.DIRECTORY_SEPARATOR.$fileName.'_mapping.yaml';
         if (!is_file($mappingFilePath)) {
             throw new InvalidException(sprintf('Mapping file "%s" not found.', $mappingFilePath));
         }


### PR DESCRIPTION
Hi, we have an use case where we'd like to specify one mapping for multiple indexes (one index per locale).
This change would allow this use case without breaking existing code.