### PR TITLE
Fix getIndexNameFromClass with index prefix

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -74,7 +74,7 @@ class Client extends ElasticaClient
             throw new RuntimeException(sprintf('The given type (%s) does not exist in the configuration.', $className));
         }
 
-        return $indexName;
+        return $this->getPrefixedIndex($indexName);
     }
 
     public function getPureIndexName(string $fullIndexName): string

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -137,10 +137,9 @@ class Indexer
     {
         if ($this->getQueueSize() >= $this->bulkMaxSize) {
             $this->flush();
-
         }
     }
-  
+
     public function getBulkRequestParams(): array
     {
         return $this->bulkRequestParams;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -37,7 +37,6 @@ final class ClientTest extends BaseTestCase
 
     public function testIndexNameFromClassWithConfigIndexPrefix(): void
     {
-
         $client = new Client([
             Client::CONFIG_INDEX_CLASS_MAPPING => [
                 'todo' => TestDTO::class,

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -34,4 +34,18 @@ final class ClientTest extends BaseTestCase
 
         $client->getIndexNameFromClass(TestDTO::class);
     }
+
+    public function testIndexNameFromClassWithConfigIndexPrefix(): void
+    {
+
+        $client = new Client([
+            Client::CONFIG_INDEX_CLASS_MAPPING => [
+                'todo' => TestDTO::class,
+            ],
+            Client::CONFIG_INDEX_PREFIX => 'foo',
+        ]);
+
+        $indexName = $client->getIndexNameFromClass(TestDTO::class);
+        $this->assertSame('foo_todo', $indexName);
+    }
 }


### PR DESCRIPTION
`getIndexNameFromClass` now also working when using an index-prefix configuration.