### PR TITLE
PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "ruflin/elastica": "^7.0",


### PR DESCRIPTION
 Your requirements could not be resolved to an installable set of packages.
php_1             |
php_1             |   Problem 1
php_1             |     - jolicode/elastically[v1.1.0, ..., v1.1.1] require php ^7.2 -> your php version (8.0.2) does not satisfy that requirement.
php_1             |     - Root composer.json requires jolicode/elastically ^1.1 -> satisfiable by jolicode/elastically[v1.1.0, v1.1.1].