### PR TITLE
deprecates `Index::getBuilder()` in favor of `Client::getBuilder()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Deprecated
+
+* deprecates `Index::getBuilder()` in favor of `Client::getBuilder()`
+
 ## [1.2.0] - 2021-02-16
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ext-json": "*",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "ruflin/elastica": "^7.0",
+        "symfony/deprecation-contracts": "^2.4",
         "symfony/property-access": "^3.4|^4.0|^5.0",
         "symfony/property-info": "^3.4|^4.0|^5.0",
         "symfony/serializer": "^3.4|^4.0|^5.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,7 @@ class Client extends ElasticaClient
 
     private $indexer;
     private $indexBuilder;
+    private $builder;
 
     public function getIndexBuilder(): IndexBuilder
     {
@@ -50,6 +51,15 @@ class Client extends ElasticaClient
         }
 
         return $this->indexer;
+    }
+
+    public function getBuilder(): ResultSetBuilder
+    {
+        if (!$this->builder) {
+            $this->builder = new ResultSetBuilder($this);
+        }
+
+        return $this->builder;
     }
 
     /**

--- a/src/Index.php
+++ b/src/Index.php
@@ -17,8 +17,6 @@ use Elastica\Search;
 
 class Index extends ElasticaIndex
 {
-    private $builder;
-
     public function getModel($id)
     {
         $document = $this->getDocument($id);
@@ -28,17 +26,15 @@ class Index extends ElasticaIndex
 
     public function createSearch($query = '', $options = null, BuilderInterface $builder = null): Search
     {
-        $builder = $builder ?? $this->getBuilder();
+        $builder = $builder ?? $this->getClient()->getBuilder();
 
         return parent::createSearch($query, $options, $builder);
     }
 
     public function getBuilder(): ResultSetBuilder
     {
-        if (!$this->builder) {
-            $this->builder = new ResultSetBuilder($this->getClient());
-        }
+        trigger_deprecation('jolicode/elastically', '1.3.0', 'Method %s() is deprecated. Use %s::getBuilder() instead', __METHOD__, Client::class);
 
-        return $this->builder;
+        return $this->getClient()->getBuilder();
     }
 }


### PR DESCRIPTION
Move all di hacks to the same god object (Client)