### PR TITLE
Fixes to php-cs-fixer: ignore cache file in Git, fix Makefile usage & apply to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tests/Jane/generated/*
 !/tests/Jane/generated/.gitkeep
 .php_cs.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the jolicode/elastically library.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 $header = <<<'EOF'
 This file is part of the jolicode/elastically library.
 
@@ -12,11 +21,11 @@ EOF;
 $config = new PhpCsFixer\Config();
 $config
     ->setRiskyAllowed(true)
-    ->setRules(array(
+    ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'header_comment' => array('header' => $header),
-        'array_syntax' => array('syntax' => 'short'),
+        'header_comment' => ['header' => $header],
+        'array_syntax' => ['syntax' => 'short'],
         'ordered_class_elements' => true,
         'ordered_imports' => true,
         'heredoc_to_nowdoc' => true,
@@ -31,11 +40,14 @@ $config
         'no_useless_return' => true,
         'semicolon_after_instruction' => true,
         'combine_consecutive_unsets' => true,
-        'concat_space' => array('spacing' => 'one'),
-    ))
+        'concat_space' => ['spacing' => 'one'],
+    ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
+            ->name(['*.php', '.php-cs-fixer.php'])
+            ->ignoreDotFiles(false)
+            ->exclude('tests/Jane/generated/')
     )
 ;
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ kibana: ## Start debug tools (Kibana)
 	docker run -e "ELASTICSEARCH_HOSTS=http://127.0.0.1:9200/" --network host docker.elastic.co/kibana/kibana-oss:7.8.0
 
 cs: ## Fix PHP CS
-	./vendor/bin/php-cs-fixer fix --verbose --rules=@Symfony,ordered_imports src/
-	./vendor/bin/php-cs-fixer fix --verbose --rules=@Symfony,ordered_imports tests/
+	./vendor/bin/php-cs-fixer fix --verbose
 
 .PHONY: help
 


### PR DESCRIPTION
Hi,

This PR aims to fix the following:

- includes .php-cs-fixer.php to the files to fix (& apply fixes to it)
- ignore the Jane generated files in the tests directory
- ignores php-cs-fixer cache file in Git
- fix Makefile usage to make it consistent with CI & config
