### PR TITLE
phpstan: allow to run locally & create base config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               env:
                 REQUIRE_DEV: true
               with:
-                args: analyse --level=5 --configuration=phpstan-baseline.neon src/
+                args: analyse
 
     ci:
         name: Test PHP ${{ matrix.php-version }} ${{ matrix.name }}

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ cs: ## Fix PHP CS
 	./vendor/bin/php-cs-fixer fix --verbose --rules=@Symfony,ordered_imports src/
 	./vendor/bin/php-cs-fixer fix --verbose --rules=@Symfony,ordered_imports tests/
 
+phpstan: # Run phpstan
+	./vendor/bin/phpstan analyse
+
 .PHONY: help
 
 help: ## Display this help

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "jane-php/json-schema": "^6.0",
         "jane-php/json-schema-runtime": "^6.0",
+        "phpstan/phpstan": "^0.12.93",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/http-client": "^4.4|^5.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src


### PR DESCRIPTION
Hi,

I noticed I couldn't run phpstan locally & it would only run in CI, so:

- added phpstan to dev requirements
- created config to share between CI & local runs
- added phpstan in Makefile