### PR TITLE
Remove legacy PHP-CS-Fixer cache file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 /vendor/
 /tests/Jane/generated/*
 !/tests/Jane/generated/.gitkeep
-.php_cs.cache
 .php-cs-fixer.cache


### PR DESCRIPTION
This should not be needed anymore, as it's the name of the cache file from PHP-CS-Fixer 2 (see: [upgrade docs](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/UPGRADE-v3.md#rename-of-files))