### PR TITLE
Fix index name mapper getting pure index name frome alias

### DIFF
--- a/src/IndexNameMapper.php
+++ b/src/IndexNameMapper.php
@@ -65,6 +65,17 @@ class IndexNameMapper
             return $matches[1];
         }
 
+        $prefixLength = strlen($this->prefix);
+
+        if ($this->prefix && substr($fullIndexName, 0, $prefixLength) === $this->prefix) {
+            return substr($fullIndexName, $prefixLength + 1);
+        }
+
         return $fullIndexName;
+    }
+
+    public function getMappedIndices(): array
+    {
+        return array_keys($this->indexClassMapping);
     }
 }

--- a/src/IndexNameMapper.php
+++ b/src/IndexNameMapper.php
@@ -65,7 +65,7 @@ class IndexNameMapper
             return $matches[1];
         }
 
-        $prefixLength = strlen($this->prefix);
+        $prefixLength = \strlen($this->prefix);
 
         if ($this->prefix && substr($fullIndexName, 0, $prefixLength) === $this->prefix) {
             return substr($fullIndexName, $prefixLength + 1);

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -34,7 +34,7 @@ class Indexer
 
         $this->client = $client;
         $this->serializer = $serializer;
-        $this->bulkMaxSize = $bulkMaxSize ?? 100;
+        $this->bulkMaxSize = $bulkMaxSize;
         $this->bulkRequestParams = $bulkRequestParams;
         $this->contextBuilder = $contextBuilder ?? new StaticContextBuilder();
     }

--- a/src/Transport/HttpClientTransport.php
+++ b/src/Transport/HttpClientTransport.php
@@ -87,7 +87,7 @@ class HttpClientTransport extends AbstractTransport
         try {
             $response = $this->client->request($method, $this->_getUri($request, $connection), $options);
             $elasticaResponse = new Response($response->getContent(), $response->getStatusCode());
-        } catch (ClientException | ServerException $e) { // Error 4xx and 5xx
+        } catch (ClientException|ServerException $e) { // Error 4xx and 5xx
             $elasticaResponse = new Response($response->getContent(false), $response->getStatusCode());
         } catch (HttpExceptionInterface $e) {
             throw new HttpException($e->getCode(), $request);

--- a/tests/IndexNameMapperTest.php
+++ b/tests/IndexNameMapperTest.php
@@ -49,4 +49,61 @@ final class IndexNameMapperTest extends BaseTestCase
         $indexName = $mapper->getIndexNameFromClass(TestDTO::class);
         $this->assertSame('foo_todo', $indexName);
     }
+
+    public function testPureIndexNameFromIndex(): void
+    {
+        $mapper = new IndexNameMapper(null, [
+            'todo' => TestDTO::class,
+        ]);
+
+        $pureIndexName = $mapper->getPureIndexName('todo_2222-22-22-000001');
+        $this->assertSame('todo', $pureIndexName);
+    }
+
+    public function testPureIndexNameFromIndexPrefix(): void
+    {
+        $mapper = new IndexNameMapper('foo', [
+            'todo' => TestDTO::class,
+        ]);
+
+        $pureIndexName = $mapper->getPureIndexName('foo_todo_2222-22-22-000001');
+        $this->assertSame('todo', $pureIndexName);
+    }
+    public function testPureIndexNameFromIndexAlias(): void
+    {
+        $mapper = new IndexNameMapper(null, [
+            'todo' => TestDTO::class,
+        ]);
+
+        $pureIndexName = $mapper->getPureIndexName('todo');
+        $this->assertSame('todo', $pureIndexName);
+    }
+
+    public function testPureIndexNameFromIndexAliasPrefix(): void
+    {
+        $mapper = new IndexNameMapper('foo', [
+            'todo' => TestDTO::class,
+        ]);
+
+        $pureIndexName = $mapper->getPureIndexName('foo_todo');
+        $this->assertSame('todo', $pureIndexName);
+    }
+
+    public function testMappedIndices(): void
+    {
+        $mapper = new IndexNameMapper('foo', [
+            'todo' => TestDTO::class,
+            'bar' => TestBarDTO::class,
+        ]);
+        $mappedIndices = $mapper->getMappedIndices();
+        $this->assertCount(2, $mappedIndices);
+        $this->assertContains('todo', $mappedIndices);
+        $this->assertContains('bar', $mappedIndices);
+    }
+}
+
+class TestBarDTO
+{
+    public $bar;
+    public $baz;
 }

--- a/tests/IndexNameMapperTest.php
+++ b/tests/IndexNameMapperTest.php
@@ -69,6 +69,7 @@ final class IndexNameMapperTest extends BaseTestCase
         $pureIndexName = $mapper->getPureIndexName('foo_todo_2222-22-22-000001');
         $this->assertSame('todo', $pureIndexName);
     }
+
     public function testPureIndexNameFromIndexAlias(): void
     {
         $mapper = new IndexNameMapper(null, [


### PR DESCRIPTION
* getPureIndexName now properly deals with prefixed aliases

* add Tests for getPureIndexName

* add function getMappedIndices to get a list of valid indices