### PR TITLE
Allow symfony/deprecation-contracts 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "phpdocumentor/reflection-docblock": "^4.4|^5.0",
         "ruflin/elastica": "^7.0",
-        "symfony/deprecation-contracts": "^2.4",
+        "symfony/deprecation-contracts": "^2.4 || ^3.0",
         "symfony/property-access": "^4.4 || ^5.0 || ^6.0",
         "symfony/property-info": "^4.4 || ^5.0 || ^6.0",
         "symfony/serializer": "^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
Hi

Just a small patch to allow symfony/deprecation-contracts 3.0 (only one commit between 2.5 and 3.0 : https://github.com/symfony/deprecation-contracts/commit/c726b64c1ccfe2896cb7df2e1331c357ad1c8ced)

Signed-off-by: Guillaume Roques <guillaume.roques@gmail.com>