### PR TITLE
Force nikic/php-parser >= 4.7 because of a strange bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
         "symfony/messenger": "^4.4 || ^5.0 || ^6.0",
         "symfony/phpunit-bridge": "^5.2 || ^6.0"
     },
+    "conflict": {
+        "nikic/php-parser": "<4.7"
+    },
     "autoload": {
         "psr-4": {
             "JoliCode\\Elastically\\": "./src"


### PR DESCRIPTION
Without this patch, we get the following error:

```
SYMFONY_REQUIRE=5.4 composer up --prefer-lowest && vendor/bin/simple-phpunit tests/Jane/JaneTest.php
```

```
Testing JoliCode\Elastically\Tests\Jane\JaneTest
Jane (JoliCode\Elastically\Tests\Jane\Jane)
 ✘ Create index and search with jane object
   ┐
   ├ Undefined array key 265
   │
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/nikic/php-parser/lib/PhpParser/Lexer.php:255
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:209
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:159
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:51
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:32
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/jane-php/json-schema/Generator/RuntimeGenerator.php:30
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/jane-php/json-schema/Generator/ChainGenerator.php:28
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/vendor/jane-php/json-schema/Console/Command/GenerateCommand.php:67
   ╵ /home/gregoire/dev/github.com/jolicode/elastically/tests/Jane/JaneTest.php:49
   ┴

Time: 0