### PR TITLE
Accept more flexible client configuration by declaring it as variable

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -28,13 +28,13 @@ class Configuration implements ConfigurationInterface
                     ->normalizeKeys(false)
                     ->prototype('array')
                         ->children()
-                            ->arrayNode('client')
+                            ->variableNode('client')
                                 ->info('All options for the Elastica client constructor')
                                 ->example([
                                     'host' => '%env(ELASTICSEARCH_HOST)%',
                                     'transport' => '@JoliCode\Elastically\Transport\HttpClientTransport',
                                 ])
-                                ->prototype('variable')->end()
+                                ->defaultValue([])
                             ->end()
                             ->scalarNode('mapping_directory')
                                 ->info('Path to the mapping directory (in YAML)')


### PR DESCRIPTION
This will allow us to do stuff as following: 
```yaml
# config/packages/elastically.yaml
elastically:
    connections:
        default:
            client: '%env(json:ELASTICSEARCH_CONFIG)%'
            mapping_directory: '%kernel.project_dir%/config/elasticsearch'

            index_class_mapping:
                my-foobar-index:     App\Dto\Foobar
```
With `ELASTICSEARCH_CONFIG='{ "host": "elasticsearch", "port": 9200, "timeout": 4, "persistent": true }'`