### PR TITLE
ci: upgrade PHPStan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "friendsofphp/php-cs-fixer": "^3.3.2",
         "jane-php/json-schema": "^7.2",
         "jane-php/json-schema-runtime": "^7.2",
-        "phpstan/phpstan": "^0.12.93",
+        "phpstan/phpstan": "^1.9",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/http-client": "^5.4 || ^6.0",


### PR DESCRIPTION
Changelogs summary:

 - phpstan/phpstan updated from 0.12.100 to 1.9.14 major
   See changes: https://github.com/phpstan/phpstan/compare/0.12.100...1.9.14
   Release notes: https://github.com/phpstan/phpstan/releases/tag/1.9.14