### PR TITLE
ci: change PHP-CS-Fixer config for PHP 8.0

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -29,7 +29,7 @@ $finder = PhpCsFixer\Finder::create()
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PHP74Migration' => true,
+        '@PHP80Migration' => true,
         '@PhpCsFixer' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,


### PR DESCRIPTION
Perhaps ```PHP82Migration``` would be better.