### PR TITLE
doc(symfony): Provide a working example out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ elastically:
         default:
             client:
                 host:                '%env(ELASTICSEARCH_HOST)%'
-                # If you want to use the Symfony Http Client:
-                transport:           'JoliCode\Elastically\Transport\HttpClientTransport'
+                # If you want to use the Symfony HttpClient (you MUST create this service)
+                #transport:           'JoliCode\Elastically\Transport\HttpClientTransport'
 
             # Path to the mapping directory (in YAML)
             mapping_directory:       '%kernel.project_dir%/config/elasticsearch'


### PR DESCRIPTION
The example in the documentation was not working out of the box.

The HttpClientTransport MUST be declared first:

```yaml
JoliCode\Elastically\Transport\HttpClientTransport: ~
```

So I think it's better to comment it out.

Also, what about forcing this transport when using Symfony?!