### PR TITLE
Avoid BC-break in DocumentExchangerInterface

### DIFF
--- a/src/Messenger/DocumentExchangerInterface.php
+++ b/src/Messenger/DocumentExchangerInterface.php
@@ -11,9 +11,9 @@
 
 namespace JoliCode\Elastically\Messenger;
 
-use JoliCode\Elastically\Model\Document;
+use Elastica\Document as ElasticaDocument;
 
 interface DocumentExchangerInterface
 {
-    public function fetchDocument(string $className, string $id): ?Document;
+    public function fetchDocument(string $className, string $id): ?ElasticaDocument;
 }


### PR DESCRIPTION
I found a non-needed BC-break in the previous PR https://github.com/jolicode/elastically/pull/150/files#diff-7edcfcd1433b5f1ec1ee43a58328239c89877af7405d35f84ee399eb4bbc251bL14 which was taken from the original https://github.com/jolicode/elastically/pull/149/files#diff-7edcfcd1433b5f1ec1ee43a58328239c89877af7405d35f84ee399eb4bbc251bL14

This PR revert the BC break. I think this require a 1.7.1 release.

@lyrixx @damienalexandre 