### PR TITLE
feature(IndexBuilder): add dry mode in function purgeOldIndices

### DIFF
--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -96,7 +96,7 @@ class IndexBuilder
         return $newIndex;
     }
 
-    public function purgeOldIndices(string $indexName): array
+    public function purgeOldIndices(string $indexName, bool $dryRun = false): array
     {
         $indexName = $this->indexNameMapper->getPrefixedIndex($indexName);
 
@@ -149,13 +149,17 @@ class IndexBuilder
 
             if ($livePassed && $afterLiveCounter > 1) {
                 // Remove
-                $index = new \Elastica\Index($this->client, $realIndexName);
-                $index->delete();
+                if (false === $dryRun) {
+                    $index = new \Elastica\Index($this->client, $realIndexName);
+                    $index->delete();
+                }
                 $operations[] = sprintf('%s deleted.', $realIndexName);
             } elseif ($livePassed && 1 === $afterLiveCounter) {
                 // Close
-                $index = new \Elastica\Index($this->client, $realIndexName);
-                $index->close();
+                if (false === $dryRun) {
+                    $index = new \Elastica\Index($this->client, $realIndexName);
+                    $index->close();
+                }
                 $operations[] = sprintf('%s closed.', $realIndexName);
             }
         }


### PR DESCRIPTION
Hi there,

In a project, I wanted to remove old indices on my ES cluster. However I did not want to run `IndexBuilder::purgeOldIndices()` in live mode risking to wrongly delete an indice.

Here's why a propose to add a dry mode on `IndexBuilder::purgeOldIndices()` to allow listing which operations would be performed if ran in live mode.

Do you think this would be usefull / relevant ?