### PR TITLE
Add missing @throws annotation

### DIFF
--- a/src/Bridge/Symfony/Resources/config/services.php
+++ b/src/Bridge/Symfony/Resources/config/services.php
@@ -75,6 +75,5 @@ return static function (ContainerConfigurator $container) {
                 '$client' => abstract_arg('elastically.abstract.client'),
                 '$indexNameMapper' => abstract_arg('elastically.abstract.index_name_mapper'),
             ])
-
     ;
 };

--- a/src/Index.php
+++ b/src/Index.php
@@ -11,6 +11,7 @@
 
 namespace JoliCode\Elastically;
 
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Index as ElasticaIndex;
 use Elastica\ResultSet\BuilderInterface;
 use Elastica\Search;
@@ -26,6 +27,9 @@ class Index extends ElasticaIndex
         $this->resultSetBuilder = $resultSetBuilder;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function getModel($id)
     {
         $document = $this->getDocument($id);

--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -11,6 +11,7 @@
 
 namespace JoliCode\Elastically;
 
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Exception\RuntimeException;
 use Elastica\Reindex;
 use Elastica\Request;
@@ -32,6 +33,9 @@ class IndexBuilder
         $this->indexNameMapper = $indexNameMapper;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function createIndex(string $indexName, array $context = []): Index
     {
         $mapping = $this->mappingProvider->provideMapping($indexName, $context);
@@ -60,16 +64,25 @@ class IndexBuilder
         return $this->client->request('_aliases', Request::POST, $data);
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function slowDownRefresh(Index $index): void
     {
         $index->getSettings()->setRefreshInterval('60s');
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function speedUpRefresh(Index $index): void
     {
         $index->getSettings()->setRefreshInterval('1s');
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function migrate(Index $currentIndex, array $params = [], array $context = []): Index
     {
         $pureIndexName = $this->indexNameMapper->getPureIndexName($currentIndex->getName());
@@ -96,6 +109,9 @@ class IndexBuilder
         return $newIndex;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function purgeOldIndices(string $indexName, bool $dryRun = false): array
     {
         $indexName = $this->indexNameMapper->getPrefixedIndex($indexName);

--- a/src/IndexNameMapper.php
+++ b/src/IndexNameMapper.php
@@ -11,6 +11,7 @@
 
 namespace JoliCode\Elastically;
 
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Exception\RuntimeException;
 
 class IndexNameMapper
@@ -33,6 +34,9 @@ class IndexNameMapper
         return $name;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function getIndexNameFromClass(string $className): string
     {
         $indexName = array_search($className, $this->indexClassMapping, true);
@@ -44,6 +48,9 @@ class IndexNameMapper
         return $this->getPrefixedIndex($indexName);
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function getClassFromIndexName(string $indexName): string
     {
         if (!isset($this->indexClassMapping[$indexName])) {

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -13,6 +13,7 @@ namespace JoliCode\Elastically;
 
 use Elastica\Bulk;
 use Elastica\Document as ElasticaDocument;
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Index;
 use JoliCode\Elastically\Model\Document;
 use JoliCode\Elastically\Serializer\ContextBuilderInterface;
@@ -40,6 +41,9 @@ class Indexer
         $this->contextBuilder = $contextBuilder ?? new StaticContextBuilder();
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function scheduleIndex($index, ElasticaDocument $document)
     {
         $document->setIndex($index instanceof Index ? $index->getName() : $index);
@@ -50,6 +54,9 @@ class Indexer
         $this->flushIfNeeded();
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function scheduleDelete($index, string $id)
     {
         $document = new Document($id);
@@ -59,6 +66,9 @@ class Indexer
         $this->flushIfNeeded();
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function scheduleUpdate($index, ElasticaDocument $document)
     {
         $document->setIndex($index instanceof Index ? $index->getName() : $index);
@@ -69,6 +79,9 @@ class Indexer
         $this->flushIfNeeded();
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function scheduleCreate($index, ElasticaDocument $document)
     {
         $document->setIndex($index instanceof Index ? $index->getName() : $index);
@@ -79,6 +92,9 @@ class Indexer
         $this->flushIfNeeded();
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function flush(): ?Bulk\ResponseSet
     {
         if (!$this->currentBulk) {
@@ -107,6 +123,9 @@ class Indexer
         return \count($this->currentBulk->getActions());
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function refresh($index)
     {
         $indexName = $index instanceof Index ? $index->getName() : $index;
@@ -144,6 +163,9 @@ class Indexer
         return $this->currentBulk;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     protected function flushIfNeeded(): void
     {
         if ($this->getQueueSize() >= $this->bulkMaxSize) {

--- a/src/Mapping/MappingProviderInterface.php
+++ b/src/Mapping/MappingProviderInterface.php
@@ -11,7 +11,12 @@
 
 namespace JoliCode\Elastically\Mapping;
 
+use Elastica\Exception\ExceptionInterface;
+
 interface MappingProviderInterface
 {
+    /**
+     * @throws ExceptionInterface
+     */
     public function provideMapping(string $indexName, array $context = []): ?array;
 }

--- a/src/Messenger/IndexationRequestHandler.php
+++ b/src/Messenger/IndexationRequestHandler.php
@@ -12,6 +12,7 @@
 namespace JoliCode\Elastically\Messenger;
 
 use Elastica\Exception\Bulk\ResponseException;
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Exception\RuntimeException;
 use JoliCode\Elastically\Client;
 use JoliCode\Elastically\Indexer;
@@ -54,6 +55,9 @@ class IndexationRequestHandler
         $this->client->setLogger(new NullLogger());
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function __invoke(IndexationRequestInterface $message)
     {
         $messages = [];
@@ -107,6 +111,9 @@ class IndexationRequestHandler
         }
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     private function schedule(Indexer $indexer, IndexationRequest $indexationRequest)
     {
         try {

--- a/src/ResultSetBuilder.php
+++ b/src/ResultSetBuilder.php
@@ -12,6 +12,7 @@
 namespace JoliCode\Elastically;
 
 use Elastica\Document as ElasticaDocument;
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Exception\RuntimeException;
 use Elastica\Query;
 use Elastica\Response;
@@ -36,6 +37,9 @@ class ResultSetBuilder implements BuilderInterface
         $this->denormalizer = $denormalizer;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function buildResultSet(Response $response, Query $query): ResultSet
     {
         $data = $response->getData();
@@ -54,11 +58,17 @@ class ResultSetBuilder implements BuilderInterface
         return new ResultSet($response, $query, $results);
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function buildModelFromIndexAndData(string $indexName, $source)
     {
         return $this->buildModel($source, $indexName, []);
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function buildModelFromDocument(ElasticaDocument $document)
     {
         return $this->buildModel($document->getData(), $document->getIndex(), [
@@ -66,6 +76,9 @@ class ResultSetBuilder implements BuilderInterface
         ]);
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     private function buildModelFromResult(Result $result)
     {
         if (!$result->getIndex()) {
@@ -77,6 +90,9 @@ class ResultSetBuilder implements BuilderInterface
         ]);
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     private function buildModel($source, string $indexName, array $context)
     {
         if (!$source) {


### PR DESCRIPTION
Hi @lyrixx @damienalexandre,

I recently added a lot of missing `@throws` tag to the Elastica lib with https://github.com/ruflin/Elastica/pull/2153
I saw the same were missing in Elastically so here is the PR.

When using PHPStan, it can report exceptions which are not caught if and only if the library is correctly using the @throws annotations. Same for PHPStorm. So this PHPDoc is really helpful.