### PR TITLE
Use specific channel for logs

### DIFF
--- a/src/Bridge/Symfony/Resources/config/services.php
+++ b/src/Bridge/Symfony/Resources/config/services.php
@@ -51,6 +51,7 @@ return static function (ContainerConfigurator $container) {
                 '$resultSetBuilder' => abstract_arg('elastically.abstract.result_set_builder'),
                 '$indexNameMapper' => abstract_arg('elastically.abstract.index_name_mapper'),
             ])
+            ->tag('monolog.logger', ['channel' => 'elastically'])
 
         ->set('elastically.abstract.indexer', Indexer::class)
             ->abstract()


### PR DESCRIPTION
Hi @lyrixx @damienalexandre,

I recently saw logs in the `app` channel coming from Elastica failure inside vendors.
I think the `app` channel should be reserved to the App folder code.
Doctrine use a `doctrine` channel, Symfony use different channels like `request`, `messenger`, ...

To me elastically should do the same when passing the logger to the elastica client.
This PR fix this by using a custom `elastically` channel for the logs. (I hope I'm doing it right)