### PR TITLE
Do not wait for Elasticsearch reindex to finish

### DIFF
--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -87,7 +87,7 @@ class IndexBuilder
         if (!$waitForCompletion) {
             return $newIndex;
         }
-        
+
         $taskId = $response->getData()['task'];
 
         $task = new Task($this->client, $taskId);


### PR DESCRIPTION
I have a use case where I don't care that the Elasticsearch reindex is done before switching the index as live. So I would like to make this change.

Hope this is fine to you guys ? :)