### PR TITLE
Update to allow Symfony 7 and test on PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
                       symfony-version: '6.*'
                       composer-flags: ''
                       es-version: '8.2.0'
+                    # PHP 8.3, latest SF 7, ES 8
+                    - php-version: '8.3'
+                      symfony-version: '7.*'
+                      composer-flags: ''
+                      es-version: '8.2.0'
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -120,13 +125,18 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '8.1'
+                    - php-version: '8.3'
                       symfony-version: '6.*'
                       composer-flags: ''
                       os-version: 1.3.6
                       os-image: opensearchproject/opensearch:1.3.6
-                    - php-version: '8.1'
+                    - php-version: '8.3'
                       symfony-version: '6.*'
+                      composer-flags: ''
+                      os-version: 2.3.0
+                      os-image: opensearchproject/opensearch:2.3.0
+                    - php-version: '8.3'
+                      symfony-version: '7.*'
                       composer-flags: ''
                       os-version: 2.3.0
                       os-image: opensearchproject/opensearch:2.3.0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Main features:
 - Symfony HttpClient compatible transport (**optional**);
 - Symfony support (**optional**):
     - See dedicated [chapter](#usage-in-symfony);
-    - Tested with Symfony 5.4 to 6;
+    - Tested with Symfony 5.4 to 7;
     - Symfony Messenger Handler support (with or without spool);
 
 > [!IMPORTANT]

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "phpdocumentor/reflection-docblock": "^4.4|^5.0",
         "ruflin/elastica": "^7.0",
         "symfony/deprecation-contracts": "^2.4 || ^3.0",
-        "symfony/property-access": "^5.4 || ^6.0",
-        "symfony/property-info": "^5.4 || ^6.0",
-        "symfony/serializer": "^5.4 || ^6.0",
-        "symfony/yaml": "^5.4 || ^6.0"
+        "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+        "symfony/property-info": "^5.4 || ^6.0 || ^7.0",
+        "symfony/serializer": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17.0",
@@ -31,11 +31,11 @@
         "jane-php/json-schema-runtime": "^7.4",
         "phpstan/phpstan": "^1.9",
         "symfony/browser-kit": "^5.4 || ^6.0",
-        "symfony/framework-bundle": "^5.4.17 || ^6.0",
-        "symfony/http-client": "^5.4 || ^6.0",
-        "symfony/http-foundation": "^5.4 || ^6.0",
-        "symfony/messenger": "^5.4 || ^6.0",
-        "symfony/phpunit-bridge": "^6.2.3"
+        "symfony/framework-bundle": "^5.4.17 || ^6.0 || ^7.0",
+        "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
+        "symfony/messenger": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^6.2.3 || ^7.0"
     },
     "conflict": {
         "nikic/php-parser": "<4.7"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="KERNEL_CLASS" value="JoliCode\Elastically\Tests\Symfony\TestKernel"/>
         <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=11"/> <!-- @see https://github.com/janephp/janephp/issues/727 -->
+        <server name="SYMFONY_PHPUNIT_REQUIRE" value="nikic/php-parser:^4" />
     </php>
 
     <listeners>

--- a/src/Bridge/Symfony/ElasticallyBundle.php
+++ b/src/Bridge/Symfony/ElasticallyBundle.php
@@ -13,4 +13,6 @@ namespace JoliCode\Elastically\Bridge\Symfony;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class ElasticallyBundle extends Bundle {}
+class ElasticallyBundle extends Bundle
+{
+}

--- a/src/Messenger/IndexationRequestInterface.php
+++ b/src/Messenger/IndexationRequestInterface.php
@@ -11,4 +11,6 @@
 
 namespace JoliCode\Elastically\Messenger;
 
-interface IndexationRequestInterface {}
+interface IndexationRequestInterface
+{
+}

--- a/tests/Messenger/MemoryQueuingFunctionalTest.php
+++ b/tests/Messenger/MemoryQueuingFunctionalTest.php
@@ -16,7 +16,7 @@ namespace JoliCode\Elastically\Tests\Messenger;
 use JoliCode\Elastically\Messenger\IndexationRequest;
 use JoliCode\Elastically\Messenger\MultipleIndexationRequest;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -105,7 +105,7 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
         $this->assertCount(0, $transportBulk->getSent());
     }
 
-    protected static function getContainer(): ContainerInterface
+    protected static function getContainer(): Container
     {
         if (method_exists(KernelTestCase::class, 'getContainer')) {
             return parent::getContainer();

--- a/tests/Messenger/MemoryQueuingFunctionalTest.php
+++ b/tests/Messenger/MemoryQueuingFunctionalTest.php
@@ -60,7 +60,7 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
 
         // Simulate Kernel Response
         $dispatcher->dispatch(
-            new ResponseEvent(self::$kernel, new Request(), Kernel::MASTER_REQUEST, new Response()),
+            new ResponseEvent(self::$kernel, new Request(), Kernel::MAIN_REQUEST, new Response()),
             KernelEvents::RESPONSE
         );
 
@@ -94,7 +94,7 @@ final class MemoryQueuingFunctionalTest extends KernelTestCase
 
         // Simulate Kernel Response
         $dispatcher->dispatch(
-            new ResponseEvent(self::$kernel, new Request(), Kernel::MASTER_REQUEST, new Response()),
+            new ResponseEvent(self::$kernel, new Request(), Kernel::MAIN_REQUEST, new Response()),
             KernelEvents::RESPONSE
         );
 

--- a/tests/Messenger/TestControllerFunctionalTest.php
+++ b/tests/Messenger/TestControllerFunctionalTest.php
@@ -15,7 +15,7 @@ namespace JoliCode\Elastically\Tests\Messenger;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Messenger\Transport\InMemoryTransport;
 
 final class TestControllerFunctionalTest extends WebTestCase
@@ -53,7 +53,7 @@ final class TestControllerFunctionalTest extends WebTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
-    protected static function getContainer(): ContainerInterface
+    protected static function getContainer(): Container
     {
         if (method_exists(KernelTestCase::class, 'getContainer')) {
             return parent::getContainer();

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -127,13 +127,25 @@ final class SearchTest extends BaseTestCase
 
 class SearchTestDummySerializer implements SerializerInterface, DenormalizerInterface
 {
-    public function denormalize($data, $class, $format = null, array $context = []): mixed {}
+    public function denormalize($data, $class, $format = null, array $context = []): mixed
+    {
+    }
 
-    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool {}
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+    {
+    }
 
-    public function serialize(mixed $data, string $format, array $context = []): string {}
+    public function serialize(mixed $data, string $format, array $context = []): string
+    {
+    }
 
-    public function deserialize(mixed $data, string $type, string $format, array $context = []): mixed {}
+    public function deserialize(mixed $data, string $type, string $format, array $context = []): mixed
+    {
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+    }
 }
 
 class SearchTestDto


### PR DESCRIPTION
Hi

I've updated the composer.json to allow Symfony ^7.0 and change the CI layout to test it against SF 7 but also 8.3 which release few days ago.

Do you want to keep supporting SF 5.4 (which ended its bug fixes period and entered security fix only https://symfony.com/releases/5.4) ? I can update this PR accordingly
I can also update to only allow 6.4 version instead of all 6.* if needed.