### PR TITLE
Solve SF 7 deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "symfony/flex": true
+            "symfony/flex": true,
+            "php-http/discovery": true
         }
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -108,7 +108,7 @@ class Configuration implements ConfigurationInterface
             ->validate()
                 ->ifTrue(fn (array $config): bool => $config['default_connection'] && !\array_key_exists($config['default_connection'], $config['connections']))
                 ->then(function (array $v) {
-                    throw new InvalidConfigurationException(sprintf('The default connection "%s" does not exists. Available connections are: "%s".', $v['default_connection'], implode('", "', array_keys($v['connections']))));
+                    throw new InvalidConfigurationException(\sprintf('The default connection "%s" does not exists. Available connections are: "%s".', $v['default_connection'], implode('", "', array_keys($v['connections']))));
                 })
             ->end()
         ;

--- a/src/Bridge/Symfony/DependencyInjection/ElasticallyExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/ElasticallyExtension.php
@@ -18,9 +18,9 @@ use JoliCode\Elastically\IndexNameMapper;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class ElasticallyExtension extends Extension
 {

--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -40,11 +40,11 @@ class IndexBuilder
     {
         $mapping = $this->mappingProvider->provideMapping($indexName, $context);
 
-        $realName = sprintf('%s_%s', $indexName, date('Y-m-d-His'));
+        $realName = \sprintf('%s_%s', $indexName, date('Y-m-d-His'));
         $index = $this->client->getIndex($realName);
 
         if ($index->exists()) {
-            throw new RuntimeException(sprintf('Index "%s" is already created, something is wrong.', $index->getName()));
+            throw new RuntimeException(\sprintf('Index "%s" is already created, something is wrong.', $index->getName()));
         }
 
         $index->create($mapping ?? []);
@@ -97,7 +97,7 @@ class IndexBuilder
         $response = $reindex->run();
 
         if (!$response->isOk()) {
-            throw new RuntimeException(sprintf('Reindex call failed. %s', $response->getError()));
+            throw new RuntimeException(\sprintf('Reindex call failed. %s', $response->getError()));
         }
 
         $taskId = $response->getData()['task'];
@@ -172,14 +172,14 @@ class IndexBuilder
                     $index = new \Elastica\Index($this->client, $realIndexName);
                     $index->delete();
                 }
-                $operations[] = sprintf('%s deleted.', $realIndexName);
+                $operations[] = \sprintf('%s deleted.', $realIndexName);
             } elseif ($livePassed && 1 === $afterLiveCounter) {
                 // Close
                 if (false === $dryRun) {
                     $index = new \Elastica\Index($this->client, $realIndexName);
                     $index->close();
                 }
-                $operations[] = sprintf('%s closed.', $realIndexName);
+                $operations[] = \sprintf('%s closed.', $realIndexName);
             }
         }
 

--- a/src/IndexNameMapper.php
+++ b/src/IndexNameMapper.php
@@ -28,7 +28,7 @@ class IndexNameMapper
     public function getPrefixedIndex(string $name): string
     {
         if ($this->prefix) {
-            return sprintf('%s_%s', $this->prefix, $name);
+            return \sprintf('%s_%s', $this->prefix, $name);
         }
 
         return $name;
@@ -42,7 +42,7 @@ class IndexNameMapper
         $indexName = array_search($className, $this->indexClassMapping, true);
 
         if (!$indexName) {
-            throw new RuntimeException(sprintf('The given type (%s) does not exist in the configuration.', $className));
+            throw new RuntimeException(\sprintf('The given type (%s) does not exist in the configuration.', $className));
         }
 
         return $this->getPrefixedIndex($indexName);
@@ -54,7 +54,7 @@ class IndexNameMapper
     public function getClassFromIndexName(string $indexName): string
     {
         if (!isset($this->indexClassMapping[$indexName])) {
-            throw new RuntimeException(sprintf('Unknown class for index "%s". Please check your configuration.', $indexName));
+            throw new RuntimeException(\sprintf('Unknown class for index "%s". Please check your configuration.', $indexName));
         }
 
         return $this->indexClassMapping[$indexName];
@@ -63,7 +63,7 @@ class IndexNameMapper
     public function getPureIndexName(string $fullIndexName): string
     {
         if ($this->prefix) {
-            $pattern = sprintf('/%s_(.+)_\d{4}-\d{2}-\d{2}-\d+/i', preg_quote($this->prefix, '/'));
+            $pattern = \sprintf('/%s_(.+)_\d{4}-\d{2}-\d{2}-\d+/i', preg_quote($this->prefix, '/'));
         } else {
             $pattern = '/(.+)_\d{4}-\d{2}-\d{2}-\d+/i';
         }

--- a/src/Mapping/PhpProvider.php
+++ b/src/Mapping/PhpProvider.php
@@ -29,7 +29,7 @@ final class PhpProvider implements MappingProviderInterface
         $fileName = $context['filename'] ?? ($indexName . '_mapping.php');
         $mappingFilePath = $this->configurationDirectory . \DIRECTORY_SEPARATOR . $fileName;
         if (!is_file($mappingFilePath)) {
-            throw new InvalidException(sprintf('Mapping file "%s" not found.', $mappingFilePath));
+            throw new InvalidException(\sprintf('Mapping file "%s" not found.', $mappingFilePath));
         }
 
         $mapping = require $mappingFilePath;

--- a/src/Mapping/YamlProvider.php
+++ b/src/Mapping/YamlProvider.php
@@ -34,7 +34,7 @@ final class YamlProvider implements MappingProviderInterface
         $fileName = $context['filename'] ?? ($indexName . '_mapping.yaml');
         $mappingFilePath = $this->configurationDirectory . \DIRECTORY_SEPARATOR . $fileName;
         if (!is_file($mappingFilePath)) {
-            throw new InvalidException(sprintf('Mapping file "%s" not found. Please check your configuration.', $mappingFilePath));
+            throw new InvalidException(\sprintf('Mapping file "%s" not found. Please check your configuration.', $mappingFilePath));
         }
 
         $mapping = $this->parser->parseFile($mappingFilePath);

--- a/src/Messenger/IndexationRequest.php
+++ b/src/Messenger/IndexationRequest.php
@@ -20,7 +20,7 @@ final class IndexationRequest implements IndexationRequestInterface
     public function __construct(string $className, string $id, string $operation = IndexationRequestHandler::OP_INDEX)
     {
         if (!\in_array($operation, IndexationRequestHandler::OPERATIONS, true)) {
-            throw new \InvalidArgumentException(sprintf('Not supported operation "%s" given.', $operation));
+            throw new \InvalidArgumentException(\sprintf('Not supported operation "%s" given.', $operation));
         }
 
         $this->className = $className;

--- a/tests/Symfony/TestKernel.php
+++ b/tests/Symfony/TestKernel.php
@@ -57,10 +57,10 @@ class TestKernel extends Kernel
             $routes->add('/with_response', TestController::class . '::withResponse', 'with_response');
         } else {
             $routeConfigurator = $routes->add('with_exception', '/with_exception');
-            $routeConfigurator->controller(sprintf('%s::withException', TestController::class));
+            $routeConfigurator->controller(\sprintf('%s::withException', TestController::class));
 
             $routeConfigurator = $routes->add('with_response', '/with_response');
-            $routeConfigurator->controller(sprintf('%s::withResponse', TestController::class));
+            $routeConfigurator->controller(\sprintf('%s::withResponse', TestController::class));
         }
     }
 }


### PR DESCRIPTION
Hi @damienalexandre @lyrixx,

I'm getting the following deprecation with SF 7
```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "JoliCode\Elastically\Bridge\Symfony\DependencyInjection\ElasticallyExtension".
```

This PR fix it.