### PR TITLE
Support for script fields

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client extends ElasticaClient
     private IndexNameMapper $indexNameMapper;
 
     /**
-     * @see \JoliCode\Elastically\Factory::buildClient
+     * @see Factory::buildClient
      */
     public function __construct($config = [], ?LoggerInterface $logger = null, ?ResultSetBuilder $resultSetBuilder = null, ?IndexNameMapper $indexNameMapper = null)
     {

--- a/tests/ResultSetBuilderTest.php
+++ b/tests/ResultSetBuilderTest.php
@@ -65,6 +65,6 @@ class ResultSetBuilderTest extends TestCase
         ;
 
         $resultSetBuilder = new ResultSetBuilder($indexNameMapper, $contextBuilder, $denormalizer);
-        $resultSetBuilder->buildModelFromIndexAndData('indexName', ['id' => 1234]);
+        $resultSetBuilder->buildModelFromIndexAndData('indexName', ['id' => 1234], []);
     }
 }


### PR DESCRIPTION
## Feature
### Support for script fields

Merge `_source` with `fields` before denormalization process.

Creating `script_fields` in search result is stored in `fields` property e.g.:

Search object:
```
{
"script_fields": {
        "foo": {
            "script": {
                "source": "params._source.bar == 'test'",
            }
        },
}
```

Result:
```
"fields": {
                    "foo": [
                        true
                    ]
                }
```