### PR TITLE
allow phpdocumentor/reflection-docblock v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.0",
         "ext-json": "*",
         "nyholm/psr7": "^1.8",
-        "phpdocumentor/reflection-docblock": "^4.4 || ^5.0",
+        "phpdocumentor/reflection-docblock": "^4.4 || ^5.0 || ^6.0",
         "ruflin/elastica": "^8.0 || ^9.0",
         "symfony/deprecation-contracts": "^2.4 || ^3.0",
         "symfony/property-access": "^5.4 || ^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
I think we can safely allow Version 6 of phpDocumentor/ReflectionDocBlock. 

The symfony/property-info dependency will take care of the exact version, it has detailed required and conflicts. 

See also #36.